### PR TITLE
Initial implementation of recursively creating models

### DIFF
--- a/Source/AssetGenerator.csproj
+++ b/Source/AssetGenerator.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Materials.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestValues.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/Common.cs
+++ b/Source/Common.cs
@@ -22,7 +22,18 @@ namespace AssetGenerator
                 new Vector3(0.0f, 0.0f, -1.0f)
             };
 
-            if (testArea == Tests.material)
+            if (testArea == Tests.materials)
+            {
+                gltf.Materials = new[]
+                {
+                    new Material
+                    {
+
+                    }
+                };
+            }
+
+            if (testArea == Tests.pbrMetallicRoughness)
             {
                 gltf.Materials = new[]
                 {

--- a/Source/Common.cs
+++ b/Source/Common.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Common
     {
-        public static void SingleTriangle(Gltf gltf, Data geometryData)
+        public static void SingleTriangle(Gltf gltf, Data geometryData, Tests testArea)
         {
             var positions = new[]
             {
@@ -22,6 +22,18 @@ namespace AssetGenerator
                 new Vector3(0.0f, 0.0f, -1.0f)
             };
 
+            if (testArea == Tests.material)
+            {
+                gltf.Materials = new[]
+                {
+                    new Material
+                    {
+                        PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+                        {
+                        }
+                    }
+                };
+            }
 
             geometryData.Writer.Write(positions);
             geometryData.Writer.Write(normals);

--- a/Source/Materials.cs
+++ b/Source/Materials.cs
@@ -1,113 +1,115 @@
-﻿using glTFLoader.Schema;
-using System.Collections.Generic;
-using static AssetGenerator.GLTFWrapper;
+﻿//Commenting out for Now. Might still be useful as an example
 
-namespace AssetGenerator
-{
-    [AssetGroup("Materials")]
-    internal static class Materials
-    {
-        [Asset("TestSingleTriangle")]
-        public static void TestSingleTriangle(string name, Gltf gltf, List<Data> dataList)
-        {
-            var geometryData = new Data(name + ".bin");
-            dataList.Add(geometryData);
+//using glTFLoader.Schema;
+//using System.Collections.Generic;
+//using static AssetGenerator.GLTFWrapper;
 
-            Common.SingleTriangle(gltf, geometryData);
+//namespace AssetGenerator
+//{
+//    [AssetGroup("Materials")]
+//    internal static class Materials
+//    {
+//        [Asset("TestSingleTriangle")]
+//        public static void TestSingleTriangle(string name, Gltf gltf, List<Data> dataList)
+//        {
+//            var geometryData = new Data(name + ".bin");
+//            dataList.Add(geometryData);
 
-            gltf.Materials = new[]
-            {
-                new Material
-                {
-                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
-                    {
-                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
-                    }
-                }
-            };
+//            Common.SingleTriangle(gltf, geometryData);
 
-            gltf.Meshes[0].Primitives[0].Material = 0;
-        }
-        [Asset("TestSingleTriangleMultipleUVSetsWrapper")]
-        public static void TestSingleTriangleMultipleUVSetsWrapper(string name, Gltf gltf, List<Data> dataList)
-        {
-            var geometryData = new Data(name + ".bin");
-            dataList.Add(geometryData);
-            GLTFWrapper wrapper = Common.SingleTriangleMultipleUVSetsWrapper(gltf, geometryData);
+//            gltf.Materials = new[]
+//            {
+//                new Material
+//                {
+//                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+//                    {
+//                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
+//                    }
+//                }
+//            };
 
-            GLTFMaterial mat = new GLTFMaterial();
+//            gltf.Meshes[0].Primitives[0].Material = 0;
+//        }
+//        [Asset("TestSingleTriangleMultipleUVSetsWrapper")]
+//        public static void TestSingleTriangleMultipleUVSetsWrapper(string name, Gltf gltf, List<Data> dataList)
+//        {
+//            var geometryData = new Data(name + ".bin");
+//            dataList.Add(geometryData);
+//            GLTFWrapper wrapper = Common.SingleTriangleMultipleUVSetsWrapper(gltf, geometryData);
 
-            mat.metallicRoughnessMaterial = new GLTFMetallicRoughnessMaterial
-            {
-                baseColorFactor = new Vector4(1.0f, 0.0f, 0.0f, 0.0f)
+//            GLTFMaterial mat = new GLTFMaterial();
 
-            };
+//            mat.metallicRoughnessMaterial = new GLTFMetallicRoughnessMaterial
+//            {
+//                baseColorFactor = new Vector4(1.0f, 0.0f, 0.0f, 0.0f)
+
+//            };
         
-            wrapper.scenes[0].meshes[0].meshPrimitives[0].material = mat;
-            wrapper.buildGLTF(gltf, geometryData);
-        }
-        [Asset("TestSingleTriangleMultipleUVSets")]
-        public static void TestSingleTriangleMultipleUVSets(string name, Gltf gltf, List<Data> dataList)
-        {
-            var geometryData = new Data(name + ".bin");
-            dataList.Add(geometryData);
-            Common.SingleTriangleMultipleUVSets(gltf, geometryData);
+//            wrapper.scenes[0].meshes[0].meshPrimitives[0].material = mat;
+//            wrapper.buildGLTF(gltf, geometryData);
+//        }
+//        [Asset("TestSingleTriangleMultipleUVSets")]
+//        public static void TestSingleTriangleMultipleUVSets(string name, Gltf gltf, List<Data> dataList)
+//        {
+//            var geometryData = new Data(name + ".bin");
+//            dataList.Add(geometryData);
+//            Common.SingleTriangleMultipleUVSets(gltf, geometryData);
 
-            gltf.Materials = new[]
-             {
-                new Material
-                {
-                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
-                    {
-                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
+//            gltf.Materials = new[]
+//             {
+//                new Material
+//                {
+//                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+//                    {
+//                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
 
-                    }
-                }
-            };
+//                    }
+//                }
+//            };
 
-            gltf.Meshes[0].Primitives[0].Material = 0;
-        }
-        [Asset("TestSinglePlane")]
-        public static void TestSinglePlane(string name, Gltf gltf, List<Data> dataList)
-        {
-            var geometryData = new Data(name + ".bin");
-            dataList.Add(geometryData);
+//            gltf.Meshes[0].Primitives[0].Material = 0;
+//        }
+//        [Asset("TestSinglePlane")]
+//        public static void TestSinglePlane(string name, Gltf gltf, List<Data> dataList)
+//        {
+//            var geometryData = new Data(name + ".bin");
+//            dataList.Add(geometryData);
 
-            Common.SinglePlane(gltf, geometryData);
+//            Common.SinglePlane(gltf, geometryData);
 
-            gltf.Materials = new[]
-            {
-                new Material
-                {
-                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
-                    {
-                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
-                    }
-                }
-            };
+//            gltf.Materials = new[]
+//            {
+//                new Material
+//                {
+//                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+//                    {
+//                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
+//                    }
+//                }
+//            };
 
-            gltf.Meshes[0].Primitives[0].Material = 0;
-        }
-        [Asset("TestSingleCube")]
-        public static void TestSingleCross(string name, Gltf gltf, List<Data> dataList)
-        {
-            var geometryData = new Data(name + ".bin");
-            dataList.Add(geometryData);
+//            gltf.Meshes[0].Primitives[0].Material = 0;
+//        }
+//        [Asset("TestSingleCube")]
+//        public static void TestSingleCross(string name, Gltf gltf, List<Data> dataList)
+//        {
+//            var geometryData = new Data(name + ".bin");
+//            dataList.Add(geometryData);
 
-            Common.SingleCube(gltf, geometryData);
+//            Common.SingleCube(gltf, geometryData);
 
-            gltf.Materials = new[]
-            {
-                new Material
-                {
-                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
-                    {
-                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
-                    }
-                }
-            };
+//            gltf.Materials = new[]
+//            {
+//                new Material
+//                {
+//                    PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+//                    {
+//                        BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
+//                    }
+//                }
+//            };
 
-            gltf.Meshes[0].Primitives[0].Material = 0;
-        }
-    }
-}
+//            gltf.Meshes[0].Primitives[0].Material = 0;
+//        }
+//    }
+//}

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -17,51 +17,67 @@ namespace AssetGenerator
 
             foreach (var combo in combos)
             {
-                string name = makeTest.GenerateName(combo);
+                    string name = makeTest.GenerateName(combo);
 
-                var gltf = new Gltf
-                {
-                    Asset = new Asset
+                    var gltf = new Gltf
                     {
-                        Generator = "glTF Asset Generator " + name,
-                        Version = "2.0",
-                    }
-                };
-
-                var dataList = new List<Data>();
-
-                var geometryData = new Data(name + ".bin");
-                dataList.Add(geometryData);
-
-                Common.SingleTriangle(gltf, geometryData);
-
-                gltf.Materials = new[]
-                {
-                    new Material
-                    {
-                        PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+                        Asset = new Asset
                         {
-                            // MAKE THIS USE THE NEW CLASS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-                            BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
+                            Generator = "glTF Asset Generator " + name,
+                            Version = "2.0",
+                        }
+                    };
+
+                    var dataList = new List<Data>();
+
+                    var geometryData = new Data(name + ".bin");
+                    dataList.Add(geometryData);
+
+                    Common.SingleTriangle(gltf, geometryData);
+
+                    gltf.Materials = new[]
+                    {
+                        new Material
+                        {
+                            PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+                            {
+                            }
+                        }
+                    };
+
+                    foreach (Parameter param in combo)
+                    {
+                        if (param.name == "BaseColorFactor")
+                        {
+                            gltf.Materials[0].PbrMetallicRoughness.BaseColorFactor = param.value;
+                        }
+
+                        if (param.name == "MetallicFactor")
+                        {
+                            gltf.Materials[0].PbrMetallicRoughness.MetallicFactor = param.value;
+                        }
+                        if (param.name == "RoughnessFactor")
+                        {
+                            gltf.Materials[0].PbrMetallicRoughness.RoughnessFactor = param.value;
                         }
                     }
-                };
 
-                gltf.Meshes[0].Primitives[0].Material = 0;
+                    gltf.Meshes[0].Primitives[0].Material = 0;
 
-                var assetFolder = Path.Combine(executingAssemblyFolder, executingAssemblyFolder + "Materials");
-                Directory.CreateDirectory(assetFolder);
+                    var assetFolder = Path.Combine(executingAssemblyFolder, executingAssemblyFolder + "\\Materials");
+                    Directory.CreateDirectory(assetFolder);
 
-                var assetFile = Path.Combine(assetFolder, name + ".gltf");
-                glTFLoader.Interface.SaveModel(gltf, assetFile);
+                    var assetFile = Path.Combine(assetFolder, name + ".gltf");
+                    glTFLoader.Interface.SaveModel(gltf, assetFile);
 
-                foreach (var data in dataList)
-                {
-                    data.Writer.Flush();
+                    foreach (var data in dataList)
+                    {
+                        data.Writer.Flush();
 
-                    var dataFile = Path.Combine(assetFolder, data.Name);
-                    File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
-                }
+                        var dataFile = Path.Combine(assetFolder, data.Name);
+                        File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
+                    }
+                
             }
         }
     }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -93,7 +93,7 @@ namespace AssetGenerator
                         gltf.Meshes[0].Primitives[0].Material = 0;
                     }
 
-                    var assetFolder = Path.Combine(executingAssemblyFolder, "Models");
+                    var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
                     Directory.CreateDirectory(assetFolder);
 
                     var assetFile = Path.Combine(assetFolder, name + ".gltf");

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -39,7 +39,6 @@ namespace AssetGenerator
                 {
                     foreach (Parameter param in combo)
                     {
-                        //TODO: Make checks that break this into sections based on test area
                         if (param.name == "BaseColorFactor")
                         {
                             gltf.Materials[0].PbrMetallicRoughness.BaseColorFactor = param.value;
@@ -54,7 +53,6 @@ namespace AssetGenerator
                         }
                     }
 
-                    //TODO: Will need checks here depending on what is being tested
                     gltf.Meshes[0].Primitives[0].Material = 0;
                 }
 

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -12,44 +12,55 @@ namespace AssetGenerator
             var executingAssembly = Assembly.GetExecutingAssembly();
             var executingAssemblyFolder = Path.GetDirectoryName(executingAssembly.Location);
 
-            foreach (var type in executingAssembly.GetTypes())
+            TestValues makeTest = new TestValues();
+            var combos = makeTest.ParameterCombos();
+
+            foreach (var combo in combos)
             {
-                var assetGroupAttribute = type.GetCustomAttribute<AssetGroupAttribute>();
-                if (assetGroupAttribute != null)
+                string name = makeTest.GenerateName(combo);
+
+                var gltf = new Gltf
                 {
-                    foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                    Asset = new Asset
                     {
-                        var assetAttribute = method.GetCustomAttribute<AssetAttribute>();
-                        if (assetAttribute != null)
+                        Generator = "glTF Asset Generator " + name,
+                        Version = "2.0",
+                    }
+                };
+
+                var dataList = new List<Data>();
+
+                var geometryData = new Data(name + ".bin");
+                dataList.Add(geometryData);
+
+                Common.SingleTriangle(gltf, geometryData);
+
+                gltf.Materials = new[]
+                {
+                    new Material
+                    {
+                        PbrMetallicRoughness = new MaterialPbrMetallicRoughness
                         {
-                            var gltf = new Gltf
-                            {
-                                Asset = new Asset
-                                {
-                                    Generator = "glTF Asset Generator " + Assembly.GetExecutingAssembly().GetName().Version,
-                                    Version = "2.0",
-                                }
-                            };
-
-                            var dataList = new List<Data>();
-
-                            method.Invoke(null, new object[] { assetAttribute.Name, gltf, dataList });
-
-                            var assetFolder = Path.Combine(executingAssemblyFolder, assetGroupAttribute.Folder);
-                            Directory.CreateDirectory(assetFolder);
-
-                            var assetFile = Path.Combine(assetFolder, assetAttribute.Name + ".gltf");
-                            glTFLoader.Interface.SaveModel(gltf, assetFile);
-
-                            foreach (var data in dataList)
-                            {
-                                data.Writer.Flush();
-
-                                var dataFile = Path.Combine(assetFolder, data.Name);
-                                File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
-                            }
+                            // MAKE THIS USE THE NEW CLASS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                            BaseColorFactor = new[] { 1.0f, 0.0f, 0.0f, 0.0f },
                         }
                     }
+                };
+
+                gltf.Meshes[0].Primitives[0].Material = 0;
+
+                var assetFolder = Path.Combine(executingAssemblyFolder, executingAssemblyFolder + "Materials");
+                Directory.CreateDirectory(assetFolder);
+
+                var assetFile = Path.Combine(assetFolder, name + ".gltf");
+                glTFLoader.Interface.SaveModel(gltf, assetFile);
+
+                foreach (var data in dataList)
+                {
+                    data.Writer.Flush();
+
+                    var dataFile = Path.Combine(assetFolder, data.Name);
+                    File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
                 }
             }
         }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -12,46 +12,38 @@ namespace AssetGenerator
             var executingAssembly = Assembly.GetExecutingAssembly();
             var executingAssemblyFolder = Path.GetDirectoryName(executingAssembly.Location);
 
-            TestValues makeTest = new TestValues();
+            TestValues makeTest = new TestValues(Tests.material);
             var combos = makeTest.ParameterCombos();
 
             foreach (var combo in combos)
             {
-                    string name = makeTest.GenerateName(combo);
+                string name = makeTest.GenerateName(combo);
 
-                    var gltf = new Gltf
+                var gltf = new Gltf
+                {
+                    Asset = new Asset
                     {
-                        Asset = new Asset
-                        {
-                            Generator = "glTF Asset Generator " + name,
-                            Version = "2.0",
-                        }
-                    };
+                        Generator = "glTF Asset Generator " + name,
+                        Version = "2.0",
+                    }
+                };
 
-                    var dataList = new List<Data>();
+                var dataList = new List<Data>();
 
-                    var geometryData = new Data(name + ".bin");
-                    dataList.Add(geometryData);
+                var geometryData = new Data(name + ".bin");
+                dataList.Add(geometryData);
 
-                    Common.SingleTriangle(gltf, geometryData);
+                Common.SingleTriangle(gltf, geometryData, makeTest.testArea);
 
-                    gltf.Materials = new[]
-                    {
-                        new Material
-                        {
-                            PbrMetallicRoughness = new MaterialPbrMetallicRoughness
-                            {
-                            }
-                        }
-                    };
-
+                if (makeTest.testArea == Tests.material)
+                {
                     foreach (Parameter param in combo)
                     {
+                        //TODO: Make checks that break this into sections based on test area
                         if (param.name == "BaseColorFactor")
                         {
                             gltf.Materials[0].PbrMetallicRoughness.BaseColorFactor = param.value;
                         }
-
                         if (param.name == "MetallicFactor")
                         {
                             gltf.Materials[0].PbrMetallicRoughness.MetallicFactor = param.value;
@@ -62,22 +54,23 @@ namespace AssetGenerator
                         }
                     }
 
+                    //TODO: Will need checks here depending on what is being tested
                     gltf.Meshes[0].Primitives[0].Material = 0;
+                }
 
-                    var assetFolder = Path.Combine(executingAssemblyFolder, executingAssemblyFolder + "\\Materials");
-                    Directory.CreateDirectory(assetFolder);
+                var assetFolder = Path.Combine(executingAssemblyFolder, "Models");
+                Directory.CreateDirectory(assetFolder);
 
-                    var assetFile = Path.Combine(assetFolder, name + ".gltf");
-                    glTFLoader.Interface.SaveModel(gltf, assetFile);
+                var assetFile = Path.Combine(assetFolder, name + ".gltf");
+                glTFLoader.Interface.SaveModel(gltf, assetFile);
 
-                    foreach (var data in dataList)
-                    {
-                        data.Writer.Flush();
+                foreach (var data in dataList)
+                {
+                    data.Writer.Flush();
 
-                        var dataFile = Path.Combine(assetFolder, data.Name);
-                        File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
-                    }
-                
+                    var dataFile = Path.Combine(assetFolder, data.Name);
+                    File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
+                }
             }
         }
     }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -51,19 +51,19 @@ namespace AssetGenerator
                             {
                                 gltf.Materials[0].Name = param.value;
                             }
-                            if (param.name == ParameterName.EmissiveFactor)
+                            else if (param.name == ParameterName.EmissiveFactor)
                             {
                                 gltf.Materials[0].EmissiveFactor = param.value;
                             }
-                            if (param.name == ParameterName.AlphaMode_MASK || param.name == ParameterName.AlphaMode_BLEND)
+                            else if (param.name == ParameterName.AlphaMode_MASK || param.name == ParameterName.AlphaMode_BLEND)
                             {
                                 gltf.Materials[0].AlphaMode = param.value;
                             }
-                            if (param.name == ParameterName.AlphaCutoff)
+                            else if (param.name == ParameterName.AlphaCutoff)
                             {
                                 gltf.Materials[0].AlphaCutoff = param.value;
                             }
-                            if (param.name == ParameterName.DoubleSided)
+                            else if (param.name == ParameterName.DoubleSided)
                             {
                                 gltf.Materials[0].DoubleSided = param.value;
                             }
@@ -80,11 +80,11 @@ namespace AssetGenerator
                             {
                                 gltf.Materials[0].PbrMetallicRoughness.BaseColorFactor = param.value;
                             }
-                            if (param.name == ParameterName.MetallicFactor)
+                            else if (param.name == ParameterName.MetallicFactor)
                             {
                                 gltf.Materials[0].PbrMetallicRoughness.MetallicFactor = param.value;
                             }
-                            if (param.name == ParameterName.RoughnessFactor)
+                            else if (param.name == ParameterName.RoughnessFactor)
                             {
                                 gltf.Materials[0].PbrMetallicRoughness.RoughnessFactor = param.value;
                             }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -39,15 +39,15 @@ namespace AssetGenerator
                 {
                     foreach (Parameter param in combo)
                     {
-                        if (param.name == "BaseColorFactor")
+                        if (param.name == ParameterName.BaseColorFactor)
                         {
                             gltf.Materials[0].PbrMetallicRoughness.BaseColorFactor = param.value;
                         }
-                        if (param.name == "MetallicFactor")
+                        if (param.name == ParameterName.MetallicFactor)
                         {
                             gltf.Materials[0].PbrMetallicRoughness.MetallicFactor = param.value;
                         }
-                        if (param.name == "RoughnessFactor")
+                        if (param.name == ParameterName.RoughnessFactor)
                         {
                             gltf.Materials[0].PbrMetallicRoughness.RoughnessFactor = param.value;
                         }

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -1,11 +1,13 @@
 ﻿using System;
-
+using System.Collections.Generic;
+using System.Linq;
 namespace AssetGenerator
 {
     public class TestValues
     {
         public Tests testArea;
         public Parameter[] parameters;
+        bool onlyBinaryParams = true;
 
         public TestValues(Tests testType)
         {
@@ -15,12 +17,13 @@ namespace AssetGenerator
             {
                 case Tests.materials:
                     {
+                        onlyBinaryParams = false;
                         parameters = new Parameter[]
                         {
                             new Parameter(ParameterName.Name, "name", false),
                             new Parameter(ParameterName.EmissiveFactor, new[] { 0.0f, 0.0f, 1.0f }, false),
-                            new Parameter(ParameterName.AlphaMode_MASK, glTFLoader.Schema.Material.AlphaModeEnum.MASK, false),
-                            new Parameter(ParameterName.AlphaMode_BLEND, glTFLoader.Schema.Material.AlphaModeEnum.BLEND, false),
+                            new Parameter(ParameterName.AlphaMode_MASK, glTFLoader.Schema.Material.AlphaModeEnum.MASK, false, 1),
+                            new Parameter(ParameterName.AlphaMode_BLEND, glTFLoader.Schema.Material.AlphaModeEnum.BLEND, false, 1),
                             new Parameter(ParameterName.AlphaCutoff, 0.2f, false),
                             new Parameter(ParameterName.DoubleSided, true, false)
                         };
@@ -49,18 +52,71 @@ namespace AssetGenerator
 
         public Parameter[][] ParameterCombos()
         {
-            var temp = PowerSet<Parameter>(parameters);
-            //TODO: Remove sets that duplicate binary entries for a single parameter (e.g. alphaMode)
-            //TODO: Remove sets that exclude a required parameter
+            Parameter[][] finalResult;
+            List<Parameter[]> removeTheseCombos = new List<Parameter[]>();
+            List<Parameter[]> keepTheseCombos = new List<Parameter[]>();
+            var combos = PowerSet<Parameter>(parameters);
 
-            return temp;
+            //TODO: Remove sets that exclude a required parameter
+            // Removes sets that duplicate binary entries for a single parameter (e.g. alphaMode)
+            if (onlyBinaryParams == false)
+            {
+                // Makes a list of combos to remove
+                foreach (var combo in combos)
+                {
+                    List<int> binarySets = new List<int>();
+                    foreach (var param in combo)
+                    {
+                        if (param.binarySet > 0)
+                        {
+                            if (binarySets.Contains(param.binarySet))
+                            {
+                                removeTheseCombos.Add(combo);
+                                break;
+                            }
+                            else
+                            {
+                                binarySets.Add(param.binarySet);
+                            }
+                        }
+                    }
+                }
+
+                // Uses the list of bad combos to trim down the original power set
+                int numCombos = combos.Count();
+                int numRemoveTheseCombos = removeTheseCombos.Count();
+                for (int x = 0; x < numCombos; x++)
+                {
+                    bool excludeCombo = false;
+                    for (int y = 0; y < numRemoveTheseCombos; y++)
+                    {                        
+                        if (combos[x] == removeTheseCombos[y])
+                        {
+                            excludeCombo = true;
+                            break;
+                        }
+                    }
+                    if (excludeCombo == false)
+                    {
+                        keepTheseCombos.Add(combos[x]);
+                    }
+                }
+                finalResult = keepTheseCombos.ToArray();
+            }
+            else
+            {
+                // If there are only binary parameters, we don't need to check for duplicates
+                finalResult = combos;
+            }
+
+            return finalResult;
         }
 
         //https://stackoverflow.com/questions/19890781/creating-a-power-set-of-a-sequence
         public static T[][] PowerSet<T>(T[] seq)
         {
             var powerSet = new T[1 << seq.Length][];
-            powerSet[0] = new T[0]; // starting only with empty set
+            powerSet[0] = new T[0]; // starting only with empty setL
             for (int i = 0; i < seq.Length; i++)
             {
                 var cur = seq[i];
@@ -100,12 +156,22 @@ namespace AssetGenerator
         public ParameterName name { get; }
         public dynamic value; // Could be a float, array of floats, or string
         public bool isRequired;
+        public int binarySet;
 
         public Parameter(ParameterName parmName, dynamic parameterValue, bool required)
         {
             name = parmName;
             value = parameterValue;
             isRequired = required;
+            binarySet = 0;
+        }
+
+        public Parameter(ParameterName parmName, dynamic parameterValue, bool required, int belongsToBinarySet)
+        {
+            name = parmName;
+            value = parameterValue;
+            isRequired = required;
+            binarySet = belongsToBinarySet;
         }
     }
 

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -17,9 +17,9 @@ namespace AssetGenerator
                 {
                     parameters = new Parameter[]
                     {
-                        new Parameter("BaseColorFactor", new[] { 1.0f, 0.0f, 0.0f, 0.0f }, false),
-                        new Parameter("MetallicFactor", 0.5f, false),
-                        new Parameter("RoughnessFactor", 0.5f, false)
+                        new Parameter(ParameterName.BaseColorFactor, new[] { 1.0f, 0.0f, 0.0f, 0.0f }, false),
+                        new Parameter(ParameterName.MetallicFactor, 0.5f, false),
+                        new Parameter(ParameterName.RoughnessFactor, 0.5f, false)
                     };
                         break;
                 }
@@ -84,11 +84,11 @@ namespace AssetGenerator
 
     public class Parameter
     {
-        public string name { get; }
+        public ParameterName name { get; }
         public dynamic value; // Could be a float, array of floats, or string
         public bool isRequired;
 
-        public Parameter(string parmName, dynamic parameterValue, bool required)
+        public Parameter(ParameterName parmName, dynamic parameterValue, bool required)
         {
             name = parmName;
             value = parameterValue;
@@ -100,5 +100,12 @@ namespace AssetGenerator
     {
         material,
         texture
+    }
+
+    public enum ParameterName
+    {
+        BaseColorFactor,
+        MetallicFactor,
+        RoughnessFactor
     }
 }

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -13,31 +13,44 @@ namespace AssetGenerator
 
             switch (testArea)
             {
-                case Tests.material:
-                {
-                    parameters = new Parameter[]
+                case Tests.materials:
                     {
+                        parameters = new Parameter[]
+                        {
+                            new Parameter(ParameterName.Name, "name", false),
+                            new Parameter(ParameterName.EmissiveFactor, new[] { 0.0f, 0.0f, 1.0f }, false),
+                            new Parameter(ParameterName.AlphaMode_MASK, glTFLoader.Schema.Material.AlphaModeEnum.MASK, false),
+                            new Parameter(ParameterName.AlphaMode_BLEND, glTFLoader.Schema.Material.AlphaModeEnum.BLEND, false),
+                            new Parameter(ParameterName.AlphaCutoff, 0.2f, false),
+                            new Parameter(ParameterName.DoubleSided, true, false)
+                        };
+                        break;
+                    }
+                case Tests.pbrMetallicRoughness:
+                    {
+                        parameters = new Parameter[]
+                        {
                         new Parameter(ParameterName.BaseColorFactor, new[] { 1.0f, 0.0f, 0.0f, 0.0f }, false),
                         new Parameter(ParameterName.MetallicFactor, 0.5f, false),
                         new Parameter(ParameterName.RoughnessFactor, 0.5f, false)
-                    };
+                        };
                         break;
-                }
+                    }
                 case Tests.texture:
-                {
-                    parameters = new Parameter[]
                     {
-                        //TODO: Add texture parameters
-                    };
-                }
-                break;
+                        parameters = new Parameter[]
+                        {
+                            //TODO: Add texture parameters
+                        };
+                    }
+                    break;
             }
         }
 
         public Parameter[][] ParameterCombos()
         {
             var temp = PowerSet<Parameter>(parameters);
-            //TODO: Handle parameters that have more than binary values (e.g. alphaMode)
+            //TODO: Remove sets that duplicate binary entries for a single parameter (e.g. alphaMode)
             //TODO: Remove sets that exclude a required parameter
 
             return temp;
@@ -98,14 +111,23 @@ namespace AssetGenerator
 
     public enum Tests
     {
-        material,
+        pbrMetallicRoughness,
+        materials,
         texture
     }
 
     public enum ParameterName
     {
+        Name,
         BaseColorFactor,
         MetallicFactor,
-        RoughnessFactor
+        RoughnessFactor,
+        EmissiveFactor,
+        AlphaMode_MASK,
+        AlphaMode_BLEND,
+        AlphaCutoff,
+        DoubleSided,
+        Sampler,
+        Source
     }
 }

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -21,7 +21,7 @@ namespace AssetGenerator
             Parameter[] parameters =
             {
                 new Parameter("BaseColorFactor", new[] { 1.0f, 0.0f, 0.0f, 0.0f }),
-                new Parameter("BetallicFactor", 0.5f),
+                new Parameter("MetallicFactor", 0.5f),
                 new Parameter("RoughnessFactor", 0.5f)
             };
 

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using glTFLoader.Schema;
+using static AssetGenerator.GLTFWrapper;
+
+namespace AssetGenerator
+{
+    public class TestValues
+    {
+        public TestValues()
+        {
+
+        }
+
+        public Parameter[][] ParameterCombos()
+        {
+            //List<Parameter> parameters = new List<Parameter>
+            Parameter[] parameters =
+            {
+                new Parameter("BaseColorFactor", new[] { 1.0f, 0.0f, 0.0f, 0.0f }),
+                new Parameter("BetallicFactor", 0.5f),
+                new Parameter("RoughnessFactor", 0.5f)
+            };
+
+            var temp = PowerSet<Parameter>(parameters);
+
+            return temp;
+        }
+
+        //https://stackoverflow.com/questions/19890781/creating-a-power-set-of-a-sequence
+        public static T[][] PowerSet<T>(T[] seq)
+        {
+            var powerSet = new T[1 << seq.Length][];
+            powerSet[0] = new T[0]; // starting only with empty set
+            for (int i = 0; i < seq.Length; i++)
+            {
+                var cur = seq[i];
+                int count = 1 << i; // doubling list each time
+                for (int j = 0; j < count; j++)
+                {
+                    var source = powerSet[j];
+                    var destination = powerSet[count + j] = new T[source.Length + 1];
+                    for (int q = 0; q < source.Length; q++)
+                        destination[q] = source[q];
+                    destination[source.Length] = cur;
+                }
+            }
+            return powerSet;
+        }
+
+        public string GenerateName(Parameter[] paramSet)
+        {
+            string name = null;
+
+            for (int i = 0; i < paramSet.Length; i++)
+            {
+                name += paramSet[i].name;
+            }
+
+            if (name == null)
+            {
+                name = "None";
+            }
+
+            return name;
+        }
+    }
+
+    public class Parameter
+    {
+        public string name { get; }
+        public dynamic value; // Could be a float, array of floats, or string
+        public bool required;
+
+        public Parameter(string parmName, dynamic parameterValue)
+        {
+            name = parmName;
+            value = parameterValue;
+            required = false;
+        }
+    }
+}

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -1,31 +1,44 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using glTFLoader.Schema;
-using static AssetGenerator.GLTFWrapper;
 
 namespace AssetGenerator
 {
     public class TestValues
     {
-        public TestValues()
-        {
+        public Tests testArea;
+        public Parameter[] parameters;
 
+        public TestValues(Tests testType)
+        {
+            testArea = testType;
+
+            switch (testArea)
+            {
+                case Tests.material:
+                {
+                    parameters = new Parameter[]
+                    {
+                        new Parameter("BaseColorFactor", new[] { 1.0f, 0.0f, 0.0f, 0.0f }, false),
+                        new Parameter("MetallicFactor", 0.5f, false),
+                        new Parameter("RoughnessFactor", 0.5f, false)
+                    };
+                        break;
+                }
+                case Tests.texture:
+                {
+                    parameters = new Parameter[]
+                    {
+                        //TODO: Add texture parameters
+                    };
+                }
+                break;
+            }
         }
 
         public Parameter[][] ParameterCombos()
         {
-            //List<Parameter> parameters = new List<Parameter>
-            Parameter[] parameters =
-            {
-                new Parameter("BaseColorFactor", new[] { 1.0f, 0.0f, 0.0f, 0.0f }),
-                new Parameter("MetallicFactor", 0.5f),
-                new Parameter("RoughnessFactor", 0.5f)
-            };
-
             var temp = PowerSet<Parameter>(parameters);
+            //TODO: Handle parameters that have more than binary values (e.g. alphaMode)
+            //TODO: Remove sets that exclude a required parameter
 
             return temp;
         }
@@ -62,7 +75,7 @@ namespace AssetGenerator
 
             if (name == null)
             {
-                name = "None";
+                name = "NoParametersSet";
             }
 
             return name;
@@ -73,13 +86,19 @@ namespace AssetGenerator
     {
         public string name { get; }
         public dynamic value; // Could be a float, array of floats, or string
-        public bool required;
+        public bool isRequired;
 
-        public Parameter(string parmName, dynamic parameterValue)
+        public Parameter(string parmName, dynamic parameterValue, bool required)
         {
             name = parmName;
             value = parameterValue;
-            required = false;
+            isRequired = required;
         }
+    }
+
+    public enum Tests
+    {
+        material,
+        texture
     }
 }


### PR DESCRIPTION
TestValues.cs creates an object which holds the values we want to make models with. It also includes a helper function which creates a power set (all possible combinations) of those values.

Program.cs leverages this object to iterate through creating the models.

Note that I've commented out the contents of Materials.cs. The functionality of that code has been moved into Common.cs and Program.cs, but I thought to keep it around for a little bit longer as example code until we've more firmly landed this feature. 

**Outstanding issues:**

- [ ] Only the SingleTriangle fuction in common.cs has been updated with the gltf.Materials constructor. The other model types will need to be updated before they are used.

- [ ] All test values other than those used by PBR and basic materials need to be added. Textures should be added next.

- [ ] The powerset function does not handle required parameters yet

- [ ] I'm not happy with the current file naming scheme. It has the potential of creating files with way too long of names, given a large enough parameter set.

- [ ] Bunches of if statements in program.cs isn't great. There is probably a better way to do this.