### PR TITLE
Add AlphaMode field to GLTFMaterial

### DIFF
--- a/Source/GLTFWrapper.cs
+++ b/Source/GLTFWrapper.cs
@@ -553,6 +553,8 @@ namespace AssetGenerator
             /// </summary>
             public Vector4? emissiveFactor;
 
+            public Material.AlphaModeEnum? alphaMode;
+
             /// <summary>
             /// Adds a texture to the property components of the GLTFWrapper.
             /// </summary>
@@ -680,6 +682,10 @@ namespace AssetGenerator
 						Index = emissiveIndicies[0],
 						TexCoord = emissiveIndicies[1]
 					};   
+                }
+                if (alphaMode.HasValue)
+                {
+                    material.AlphaMode = alphaMode.Value;
                 }
                 return material;
             }


### PR DESCRIPTION
Added the alphaMode field to GLTFMaterial, which uses the Material AlphaModeEnum.