### PR TITLE
Add missing fields for wrapper types (for materials and textures)

### DIFF
--- a/Source/GLTFWrapper.cs
+++ b/Source/GLTFWrapper.cs
@@ -264,6 +264,11 @@ namespace AssetGenerator
             /// List of meshes in the scene
             /// </summary>
             public List<GLTFMesh> meshes;
+
+            /// <summary>
+            /// The user-defined name of the scene
+            /// </summary>
+            public string name;
             public GLTFScene()
             {
                 meshes = new List<GLTFMesh>();
@@ -492,6 +497,7 @@ namespace AssetGenerator
             public int? minFilter;
             public int? wrapS;
             public int? wrapT;
+            public string name;
             /// <summary>
             /// Converts the GLTFSampler into a glTF loader Sampler object.
             /// </summary>
@@ -515,6 +521,10 @@ namespace AssetGenerator
                 {
                     sampler.WrapT = sampler.WrapT;
                 }
+                if (name != null)
+                {
+                    sampler.Name = name;
+                }
                 return sampler;
             }
         }
@@ -537,6 +547,11 @@ namespace AssetGenerator
             /// </summary>
             public GLTFSampler sampler;
 
+            /// <summary>
+            /// User defined name
+            /// </summary>
+            public string name;
+
         }
 
         /// <summary>
@@ -548,6 +563,16 @@ namespace AssetGenerator
             /// The location of the image file, or a data uri containing texture data as an encoded string
             /// </summary>
             public string uri;
+
+            /// <summary>
+            /// The user-defined name of the image
+            /// </summary>
+            public string name;
+
+            /// <summary>
+            /// The image's mimetype
+            /// </summary>
+            public Image.MimeTypeEnum? mimeType;
             /// <summary>
             /// converts the GLTFImage to a glTF Image
             /// </summary>
@@ -558,6 +583,14 @@ namespace AssetGenerator
                 {
                     Uri = uri
                 };
+                if (mimeType.HasValue)
+                {
+                    image.MimeType = mimeType.Value;
+                }
+                if (name != null)
+                {
+                    image.Name = name;
+                }
                 return image;
             }
         }
@@ -640,6 +673,10 @@ namespace AssetGenerator
                         Sampler = sampler_index,
                         Source = image_index
                     };
+                    if (name != null)
+                    {
+                        texture.Name = name; 
+                    }
                     textures.Add(texture);
                     indices.Add(textures.Count() - 1);
                     indices.Add(gTexture.texCoordIndex);

--- a/Source/GLTFWrapper.cs
+++ b/Source/GLTFWrapper.cs
@@ -49,6 +49,7 @@ namespace AssetGenerator
             List<Image> images = new List<Image>();
             List<Sampler> samplers = new List<Sampler>();
             List<Texture> textures = new List<Texture>();
+            List<Mesh> meshes = new List<Mesh>();
 
             foreach (GLTFScene scene in scenes)
             {
@@ -215,6 +216,17 @@ namespace AssetGenerator
 
                         scene_indices.Add(nodes.Count() - 1);
                     }
+                    Mesh m = new Mesh();
+                    if (mesh.name != null)
+                    {
+                        m.Name = mesh.name;
+                    }
+                    if (meshPrimitives != null)
+                    {
+                        m.Primitives = meshPrimitives.ToArray();
+                        meshPrimitives.Clear();
+                    }
+                    meshes.Add(m);
                 }
                 gltf.Scenes = new[]
                 {
@@ -224,13 +236,11 @@ namespace AssetGenerator
                     }
                 };
                 gltf.Scene = 0;
-                gltf.Meshes = new[]
+
+                if (meshes != null)
                 {
-                    new Mesh
-                    {
-                        Primitives = meshPrimitives.ToArray()
-                    }
-                };
+                    gltf.Meshes = meshes.ToArray();
+                }
                 gltf.Accessors = accessors.ToArray();
                 gltf.BufferViews = bufferViews.ToArray();
                 gltf.Buffers = buffers.ToArray();

--- a/Source/GLTFWrapper.cs
+++ b/Source/GLTFWrapper.cs
@@ -493,10 +493,25 @@ namespace AssetGenerator
         /// </summary>
         public class GLTFSampler
         {
+            /// <summary>
+            /// Magnification filter
+            /// </summary>
             public int? magFilter;
+            /// <summary>
+            /// Minification filter
+            /// </summary>
             public int? minFilter;
+            /// <summary>
+            /// S wrapping mode
+            /// </summary>
             public int? wrapS;
+            /// <summary>
+            /// T wrapping mode
+            /// </summary>
             public int? wrapT;
+            /// <summary>
+            /// User-defined name of the sampler
+            /// </summary>
             public string name;
             /// <summary>
             /// Converts the GLTFSampler into a glTF loader Sampler object.

--- a/Source/GLTFWrapper.cs
+++ b/Source/GLTFWrapper.cs
@@ -286,6 +286,10 @@ namespace AssetGenerator
         public class GLTFMesh
         {
             /// <summary>
+            /// The user-defined name of this mesh.
+            /// </summary>
+            public string name;
+            /// <summary>
             /// List of mesh primitives in the mesh
             /// </summary>
             public List<GLTFMeshPrimitive> meshPrimitives;


### PR DESCRIPTION
Added the following missing fields to these types (for the materials and textures implementation for the wrapper)

**GLTFTexture**
-  name

**GLTFImage**
-  mimeType
-  name

**GLTFSampler**
-   name

**GLTFMesh**
-  name