### PR TITLE
Change from all combinations to only make full sets and singles

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -1,8 +1,11 @@
 ﻿using glTFLoader.Schema;
 using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Reflection;
 using static AssetGenerator.GLTFWrapper;
+using System.Diagnostics;
+
 
 namespace AssetGenerator
 {
@@ -10,14 +13,16 @@ namespace AssetGenerator
     {
         private static void Main(string[] args)
         {
+            Stopwatch.StartNew();
+
             var executingAssembly = Assembly.GetExecutingAssembly();
             var executingAssemblyFolder = Path.GetDirectoryName(executingAssembly.Location);
             var imageFolder = Path.Combine(executingAssemblyFolder, "ImageDependencies");
 
             Tests[] testBatch = new Tests[]
             {
-                //Tests.Materials,
-                //Tests.PbrMetallicRoughness,
+                Tests.Materials,
+                Tests.PbrMetallicRoughness,
                 Tests.Sampler
             };
 
@@ -26,7 +31,7 @@ namespace AssetGenerator
                 TestValues makeTest = new TestValues(test);
                 var combos = makeTest.ParameterCombos();
 
-                int numCombos = combos.Length;
+                int numCombos = combos.Count;
                 for (int comboIndex = 0; comboIndex < numCombos; comboIndex++)
                 {
                     string name = makeTest.GenerateName(combos[comboIndex]);
@@ -271,6 +276,9 @@ namespace AssetGenerator
                     }
                 }
             }
+            Console.WriteLine("Model Creation Complete!");
+            Console.WriteLine("Completed in : " + TimeSpan.FromTicks(Stopwatch.GetTimestamp()).ToString());            
+            Console.ReadKey();
         }
     }
 }

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using static AssetGenerator.GLTFWrapper;
 
+
 namespace AssetGenerator
 {
     public class TestValues
     {
         public Tests testArea;
-        public Parameter[] parameters;
+        //public Parameter[] parameters;
+        public List<Parameter> parameters;
         public Parameter[] requiredParameters;
         public ImageAttribute[] imageAttributes;
         bool onlyBinaryParams = true;
@@ -32,7 +34,7 @@ namespace AssetGenerator
                         {
                             uri = "green.png"
                         };
-                        parameters = new Parameter[]
+                        parameters = new List<Parameter>
                         {
                             new Parameter(ParameterName.Name, "name", false),
                             new Parameter(ParameterName.EmissiveFactor, new Vector3(0.0f, 0.0f, 1.0f), false),
@@ -65,7 +67,7 @@ namespace AssetGenerator
                         {
                             uri = "green.png"
                         };
-                        parameters = new Parameter[]
+                        parameters = new List<Parameter>
                         {
                             new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 0.0f), false),
                             new Parameter(ParameterName.MetallicFactor, 0.5f, false),
@@ -103,7 +105,7 @@ namespace AssetGenerator
                             new Parameter(ParameterName.Name, "name", true),
                             new Parameter(ParameterName.Sampler, 0, true),
                         };
-                        parameters = new Parameter[]
+                        parameters = new List<Parameter>
                         {
                             new Parameter(ParameterName.MagFilter_NEAREST, glTFLoader.Schema.Sampler.MagFilterEnum.NEAREST, false, 1),
                             new Parameter(ParameterName.MagFilter_LINEAR, glTFLoader.Schema.Sampler.MagFilterEnum.LINEAR, false, 1),
@@ -125,14 +127,15 @@ namespace AssetGenerator
             }
         }
 
-        public Parameter[][] ParameterCombos()
+        public List<List<Parameter>> ParameterCombos()
         {
-            Parameter[][] finalResult;
-            List<Parameter[]> removeTheseCombos = new List<Parameter[]>();
-            List<Parameter[]> keepTheseCombos = new List<Parameter[]>();
+            List<List<Parameter>> finalResult;
+            List<List<Parameter>> removeTheseCombos = new List<List<Parameter>>();
+            List<List<Parameter>> keepTheseCombos = new List<List<Parameter>>();
             List<Parameter> isRequired = new List<Parameter>();
             List<ParameterName> isPrerequisite = new List<ParameterName>();
             bool prereqParam;
+
             var combos = PowerSet<Parameter>(parameters);
 
             // Removes sets that duplicate binary entries for a single parameter (e.g. alphaMode)
@@ -145,7 +148,6 @@ namespace AssetGenerator
                 // Makes a list of combos to remove
                 foreach (var combo in combos)
                 {
-                   // int reqParamCount = 0;
                     bool usedPrereq = false;
                     List<int> binarySets = new List<int>();
                     List<ParameterName> usedPrerequisite = new List<ParameterName>();
@@ -224,7 +226,8 @@ namespace AssetGenerator
                         keepTheseCombos.Add(combos[x]);
                     }
                 }
-                finalResult = keepTheseCombos.ToArray();
+                //finalResult = keepTheseCombos.ToArray();
+                finalResult = keepTheseCombos;
             }
             else
             {
@@ -239,33 +242,35 @@ namespace AssetGenerator
         /// Given a,b,c this returns all possible combinations including a full and empty set.
         /// </summary>
         /// <param name="seq"></param>
-        /// <returns>Array of Arrays containing a powerset.</returns>
+        /// <returns>List of lists containing a powerset.</returns>
         //https://stackoverflow.com/questions/19890781/creating-a-power-set-of-a-sequence
-        public static T[][] PowerSet<T>(T[] seq)
+        public static List<List<T>> PowerSet<T>(List<T> seq)
         {
-            var powerSet = new T[1 << seq.Length][];
-            powerSet[0] = new T[0]; // starting only with empty set
-            for (int i = 0; i < seq.Length; i++)
+            var powerSet = new List<List<T>>();
+            powerSet.Add(new List<T>()); // starting only with empty set
+            for (int i = 0; i < seq.Count; i++)
             {
                 var cur = seq[i];
                 int count = 1 << i; // doubling list each time
                 for (int j = 0; j < count; j++)
                 {
                     var source = powerSet[j];
-                    var destination = powerSet[count + j] = new T[source.Length + 1];
-                    for (int q = 0; q < source.Length; q++)
-                        destination[q] = source[q];
-                    destination[source.Length] = cur;
+                    powerSet.Add(new List<T>());
+                    powerSet[count + j] = new List<T>();
+                    var destination = powerSet[count + j];
+                    for (int q = 0; q < source.Count; q++)
+                        destination.Add(source[q]);
+                    destination.Add(cur);
                 }
             }
             return powerSet;
         }
 
-        public string GenerateName(Parameter[] paramSet)
+        public string GenerateName(List<Parameter> paramSet)
         {
             string name = null;
 
-            for (int i = 0; i < paramSet.Length; i++)
+            for (int i = 0; i < paramSet.Count; i++)
             {
                 if (name == null)
                 {

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -239,6 +239,27 @@ namespace AssetGenerator
         }
 
         /// <summary>
+        /// Given a,b,c this returns [a,b,c], [a], [b], [c]
+        /// </summary>
+        /// <param name="seq"></param>
+        /// <returns>List of lists containing a basic set of combinations.</returns>
+        public static List<List<T>> BasicSet<T>(List<T> seq)
+        {
+            var basicSet = new List<List<T>>();
+            basicSet.Add(new List<T>()); // Will contain the full set
+            foreach (var x in seq)
+            {
+                basicSet[0].Add(x);
+                var addList = new List<T>
+                {
+                    x
+                };
+                basicSet.Add(addList);
+            }
+            return basicSet;
+        }
+
+        /// <summary>
         /// Given a,b,c this returns all possible combinations including a full and empty set.
         /// </summary>
         /// <param name="seq"></param>

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -9,7 +9,6 @@ namespace AssetGenerator
     public class TestValues
     {
         public Tests testArea;
-        //public Parameter[] parameters;
         public List<Parameter> parameters;
         public Parameter[] requiredParameters;
         public ImageAttribute[] imageAttributes;
@@ -136,7 +135,8 @@ namespace AssetGenerator
             List<ParameterName> isPrerequisite = new List<ParameterName>();
             bool prereqParam;
 
-            var combos = PowerSet<Parameter>(parameters);
+            //var combos = PowerSet<Parameter>(parameters);
+            var combos = BasicSet<Parameter>(parameters);
 
             // Removes sets that duplicate binary entries for a single parameter (e.g. alphaMode)
             // Removes sets where an attribute is missing a required parameter
@@ -350,7 +350,7 @@ namespace AssetGenerator
     public class Parameter
     {
         public ParameterName name { get; }
-        public dynamic value; // Could be a float, array of floats, or string
+        public dynamic value; // Could be a float, array of floats, string, or enum
         public bool isRequired;
         public ParameterName prerequisite = ParameterName.Undefined;
         public int binarySet;


### PR DESCRIPTION
Now given attributes a,b,c we're creating models [a,b,c], [a], [b], [c]. This has dropped our model count from ~40,000 to 59.

I've also switched everything from arrays to lists, to avoid converting between lists and arrays. This includes the deprecated PowerSet function (which I'll leave in place for now incase there are a group of attributes that we'll want more combos on).

The console window will STAY OPEN when model creation is complete. I've added in a basic timestamp report for perf debug use.

Outstanding issues:

- [ ] Name attributes are still on individually. I plan on leaving them on only for the 'all attributes' models. This is adding maybe 5 models.
- [ ] There is a lot of cruft still in place that was being used to reduce our big combo sets. I plan on leaving the infrastructure in place to support possible future needs, but I should convert the test values we are using to something more basic since they don't need combo filtering.
- [ ] We still should make a log csv to show what attributes are used in each model.
- [ ] There are some edge case combos that need to be added back in (factors + textures)
- [ ] Attributes with prerequisites are probably broken (will probably add ~20 models)

