### PR TITLE
Stevk/logging

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -251,9 +251,6 @@ namespace AssetGenerator
                     wrapper.scenes[0].meshes[0].meshPrimitives[0].material = mat;
                     wrapper.buildGLTF(gltf, geometryData);
 
-                    //var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
-                   // Directory.CreateDirectory(assetFolder);
-
                     if (makeTest.imageAttributes != null)
                     {
                         foreach (var image in makeTest.imageAttributes)

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -44,8 +44,10 @@ namespace AssetGenerator
                     {
                         Asset = new Asset
                         {
-                            Generator = "glTF Asset Generator : " + name,
+
+                            Generator = "glTF Asset Generator",
                             Version = "2.0",
+                            Copyright = name
                         }
                     };
 
@@ -283,7 +285,8 @@ namespace AssetGenerator
                     csv.AppendLine(writeToLog);
                 }
 
-                File.WriteAllText((assetFolder + "\\log.csv"), csv.ToString());
+                var logFile = Path.Combine(assetFolder, "log.csv");
+                File.WriteAllText(logFile, csv.ToString());
             }
             Console.WriteLine("Model Creation Complete!");
             Console.WriteLine("Completed in : " + TimeSpan.FromTicks(Stopwatch.GetTimestamp()).ToString());            

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -44,7 +44,6 @@ namespace AssetGenerator
                     {
                         Asset = new Asset
                         {
-
                             Generator = "glTF Asset Generator",
                             Version = "2.0",
                             Copyright = name

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Reflection;
 using static AssetGenerator.GLTFWrapper;
 using System.Diagnostics;
-
+using System.Text;
 
 namespace AssetGenerator
 {
@@ -30,6 +30,10 @@ namespace AssetGenerator
             {
                 TestValues makeTest = new TestValues(test);
                 var combos = makeTest.ParameterCombos();
+                var csv = new StringBuilder();
+
+                var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
+                Directory.CreateDirectory(assetFolder);
 
                 int numCombos = combos.Count;
                 for (int comboIndex = 0; comboIndex < numCombos; comboIndex++)
@@ -246,8 +250,8 @@ namespace AssetGenerator
                     wrapper.scenes[0].meshes[0].meshPrimitives[0].material = mat;
                     wrapper.buildGLTF(gltf, geometryData);
 
-                    var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
-                    Directory.CreateDirectory(assetFolder);
+                    //var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
+                   // Directory.CreateDirectory(assetFolder);
 
                     if (makeTest.imageAttributes != null)
                     {
@@ -274,7 +278,12 @@ namespace AssetGenerator
                         var dataFile = Path.Combine(assetFolder, data.Name);
                         File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
                     }
+
+                    var writeToLog = string.Format("{0},{1}", comboIndex, name);
+                    csv.AppendLine(writeToLog);
                 }
+
+                File.WriteAllText((assetFolder + "\\log.csv"), csv.ToString());
             }
             Console.WriteLine("Model Creation Complete!");
             Console.WriteLine("Completed in : " + TimeSpan.FromTicks(Stopwatch.GetTimestamp()).ToString());            


### PR DESCRIPTION
We now have csv logging of the attributes used to create a model. The model number is the left field, while the right field is a list of the attributes used.

Also 
- Moved folder creation higher up so that it doesn't get unnecessarily looped.
- Moved the listing of attributes in the glTF file from Generator to Copyright. We wanted it in Extras, but there are not many options that will accept a string. We might change this again later.