### PR TITLE
changed default basecolorfactor to not create transparent models

### DIFF
--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -77,7 +77,7 @@ namespace AssetGenerator
                         };
                         parameters = new List<Parameter>
                         {
-                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 0.0f)),
+                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 0.4f)),
                             new Parameter(ParameterName.MetallicFactor, 0.5f),
                             new Parameter(ParameterName.RoughnessFactor, 0.5f),
                             new Parameter(ParameterName.BaseColorTexture, null),


### PR DESCRIPTION
Basecolorfactor had alpha set to 0, which would have made models not render.