### PR TITLE
Move PBR attributes into the materials test and tweak alpha test models

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -21,7 +21,6 @@ namespace AssetGenerator
             Tests[] testBatch = new Tests[]
             {
                 Tests.Materials,
-                Tests.PbrMetallicRoughness,
                 Tests.Sampler
             };
 
@@ -126,14 +125,13 @@ namespace AssetGenerator
                             {
                                 mat.EmissiveTexture.TexCoordIndex = param.value;
                             }
-                        }
-                    }
 
-                    else if (makeTest.testArea == Tests.PbrMetallicRoughness)
-                    {
-                        mat.MetallicRoughnessMaterial = new Runtime.MetallicRoughnessMaterial();
-                        foreach (Parameter param in combos[comboIndex])
-                        {
+                            // Only set the MetallicRoughnessMaterial if one of it's attributes will be used
+                            if (mat.MetallicRoughnessMaterial == null)
+                            {
+                                mat.MetallicRoughnessMaterial = new Runtime.MetallicRoughnessMaterial();
+                            }
+
                             if (param.name == ParameterName.BaseColorFactor)
                             {
                                 mat.MetallicRoughnessMaterial.BaseColorFactor = param.value;

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -54,7 +54,7 @@ namespace AssetGenerator
                             new Parameter(ParameterName.EmissiveTexture, null),
                             new Parameter(ParameterName.Source, image, ParameterName.EmissiveTexture),
                             new Parameter(ParameterName.TexCoord, 0, ParameterName.EmissiveTexture),
-                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 1.0f)),
+                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 8.0f)),
                             new Parameter(ParameterName.MetallicFactor, 0.5f),
                             new Parameter(ParameterName.RoughnessFactor, 0.5f),
                             new Parameter(ParameterName.BaseColorTexture, null),
@@ -74,6 +74,9 @@ namespace AssetGenerator
                         specialCombos.Add(SpecialComboCreation(
                             parameters.Find(e => e.name == ParameterName.AlphaMode_MASK),
                             parameters.Find(e => e.name == ParameterName.AlphaCutoff)));
+                        specialCombos.Add(SpecialComboCreation(
+                            parameters.Find(e => e.name == ParameterName.BaseColorFactor),
+                            parameters.Find(e => e.name == ParameterName.AlphaMode_BLEND)));
                         specialCombos.Add(SpecialComboCreation(
                             parameters.Find(e => e.name == ParameterName.BaseColorTexture),
                             parameters.Find(e => e.name == ParameterName.BaseColorFactor)));

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -54,7 +54,7 @@ namespace AssetGenerator
                             new Parameter(ParameterName.EmissiveTexture, null),
                             new Parameter(ParameterName.Source, image, ParameterName.EmissiveTexture),
                             new Parameter(ParameterName.TexCoord, 0, ParameterName.EmissiveTexture),
-                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 8.0f)),
+                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 0.8f)),
                             new Parameter(ParameterName.MetallicFactor, 0.5f),
                             new Parameter(ParameterName.RoughnessFactor, 0.5f),
                             new Parameter(ParameterName.BaseColorTexture, null),

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -76,7 +76,7 @@ namespace AssetGenerator
                         };
                         parameters = new List<Parameter>
                         {
-                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 0.4f)),
+                            new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 1.0f)),
                             new Parameter(ParameterName.MetallicFactor, 0.5f),
                             new Parameter(ParameterName.RoughnessFactor, 0.5f),
                             new Parameter(ParameterName.BaseColorTexture, null),

--- a/Source/TestValues.cs
+++ b/Source/TestValues.cs
@@ -53,29 +53,7 @@ namespace AssetGenerator
                             new Parameter(ParameterName.Strength, 0.5f, ParameterName.OcclusionTexture),
                             new Parameter(ParameterName.EmissiveTexture, null),
                             new Parameter(ParameterName.Source, image, ParameterName.EmissiveTexture),
-                            new Parameter(ParameterName.TexCoord, 0, ParameterName.EmissiveTexture)
-                        };
-                        specialCombos.Add(SpecialComboCreation(
-                            parameters.Find(e => e.name == ParameterName.EmissiveTexture),
-                            parameters.Find(e => e.name == ParameterName.EmissiveFactor)));
-                        specialCombos.Add(SpecialComboCreation(
-                            parameters.Find(e => e.name == ParameterName.AlphaMode_MASK),
-                            parameters.Find(e => e.name == ParameterName.AlphaCutoff)));
-                        break;
-                    }
-                case Tests.PbrMetallicRoughness:
-                    {
-                        noPrerequisite = false;
-                        imageAttributes = new ImageAttribute[]
-                        {
-                            new ImageAttribute(texture)
-                        };
-                        Runtime.Image image = new Runtime.Image
-                        {
-                            Uri = texture
-                        };
-                        parameters = new List<Parameter>
-                        {
+                            new Parameter(ParameterName.TexCoord, 0, ParameterName.EmissiveTexture),
                             new Parameter(ParameterName.BaseColorFactor, new Vector4(1.0f, 0.0f, 0.0f, 1.0f)),
                             new Parameter(ParameterName.MetallicFactor, 0.5f),
                             new Parameter(ParameterName.RoughnessFactor, 0.5f),
@@ -91,6 +69,12 @@ namespace AssetGenerator
                             new Parameter(ParameterName.Name, "name", ParameterName.MetallicRoughnessTexture)
                         };
                         specialCombos.Add(SpecialComboCreation(
+                            parameters.Find(e => e.name == ParameterName.EmissiveTexture),
+                            parameters.Find(e => e.name == ParameterName.EmissiveFactor)));
+                        specialCombos.Add(SpecialComboCreation(
+                            parameters.Find(e => e.name == ParameterName.AlphaMode_MASK),
+                            parameters.Find(e => e.name == ParameterName.AlphaCutoff)));
+                        specialCombos.Add(SpecialComboCreation(
                             parameters.Find(e => e.name == ParameterName.BaseColorTexture),
                             parameters.Find(e => e.name == ParameterName.BaseColorFactor)));
                         specialCombos.Add(SpecialComboCreation(
@@ -102,7 +86,7 @@ namespace AssetGenerator
                         specialCombos.Add(SpecialComboCreation(
                             parameters.Find(e => e.name == ParameterName.MetallicRoughnessTexture),
                             parameters.Find(e => e.name == ParameterName.RoughnessFactor),
-                            parameters.Find(e => e.name == ParameterName.RoughnessFactor)));
+                            parameters.Find(e => e.name == ParameterName.MetallicFactor)));
                         break;
                     }
                 case Tests.Sampler:


### PR DESCRIPTION
Alpha tests were lacking combos with the alpha factor in basecolorfactor. I've fixed this by moving the entire PBR test into the materials set, and by adding a special combo model for alphamode_Mask and the basecolorfactor (+1).

This has a zero impact on our total number of models, because the pbr full set model was combined with the materials full set model (-1).

I've also set the alpha factor to `0.8f` for now. Eventually we'll want to test more values, like 0 or opaque and an alpha factor of 1.