### PR TITLE
morphtarget support

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -146,7 +146,7 @@ namespace AssetGenerator.Runtime.Tests
             mesh.AddPrimitive(meshPrim);
             glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset);
             Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
-
+            Assert.IsTrue(m.Weights.Count() > 0);
         }
     }
 }

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -125,7 +125,7 @@ namespace AssetGenerator.Runtime.Tests
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
             int buffer_index = 0, buffer_offset = 0;
-            glTFLoader.Schema.Buffer bufer = new glTFLoader.Schema.Buffer();
+            
 
             MeshPrimitive meshPrim = new MeshPrimitive
             {
@@ -137,8 +137,10 @@ namespace AssetGenerator.Runtime.Tests
                 Positions = positions2,
                 Normals = normals
             };
+            List<MeshPrimitive> morphTargets = new List<MeshPrimitive>();
+            morphTargets.Add(morphTarget);
 
-            meshPrim.MorphTargets.Add(morphTarget);
+            meshPrim.MorphTargets = morphTargets;
             meshPrim.morphTargetWeight = 0;
             Mesh mesh = new Mesh();
             mesh.AddPrimitive(meshPrim);

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -91,5 +91,60 @@ namespace AssetGenerator.Runtime.Tests
             MeshPrimitive meshPrim = new MeshPrimitive();
             meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset, true, false, false);
         }
+
+        [TestMethod()]
+        public void GetMorphTargetsTest()
+        {
+            var positions = new List<Vector3>
+            {
+                new Vector3(1.0f, 0.0f, 0.0f),
+                new Vector3(-1.0f, 0.0f, 0.0f),
+                new Vector3(0.0f, 1.0f, 0.0f),
+            };
+
+            var positions2 = new List<Vector3>
+            {
+                new Vector3(1.0f, 0.0f, 0.0f),
+                new Vector3(-1.0f, 0.0f, 0.0f),
+                new Vector3(1.0f, 1.0f, 0.0f),
+            };
+
+            var normals = new List<Vector3>
+            {
+                new Vector3(0.0f, 0.0f, -1.0f),
+                new Vector3(0.0f, 0.0f, -1.0f),
+                new Vector3(0.0f, 0.0f, -1.0f)
+            };
+
+            List<glTFLoader.Schema.BufferView> bufferViews = new List<glTFLoader.Schema.BufferView>();
+            List<glTFLoader.Schema.Accessor> accessors = new List<glTFLoader.Schema.Accessor>();
+            List<glTFLoader.Schema.Texture> textures = new List<glTFLoader.Schema.Texture>();
+            List<glTFLoader.Schema.Material> materials = new List<glTFLoader.Schema.Material>();
+            List<glTFLoader.Schema.Sampler> samplers = new List<glTFLoader.Schema.Sampler>();
+            List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
+            glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
+            Data geometryData = new Data("test.bin");
+            int buffer_index = 0, buffer_offset = 0;
+            glTFLoader.Schema.Buffer bufer = new glTFLoader.Schema.Buffer();
+
+            MeshPrimitive meshPrim = new MeshPrimitive
+            {
+                Positions = positions,
+                Normals = normals
+            };
+            MeshPrimitive morphTarget = new MeshPrimitive
+            {
+                Positions = positions2,
+                Normals = normals
+            };
+
+            meshPrim.MorphTargets.Add(morphTarget);
+            meshPrim.morphTargetWeight = 0;
+            Mesh mesh = new Mesh();
+            mesh.AddPrimitive(meshPrim);
+            glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset);
+            Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
+
+        }
     }
 }

--- a/Source/Runtime/Mesh.cs
+++ b/Source/Runtime/Mesh.cs
@@ -68,11 +68,17 @@ namespace AssetGenerator.Runtime
         {
             glTFLoader.Schema.Mesh mesh = new glTFLoader.Schema.Mesh();
             List<glTFLoader.Schema.MeshPrimitive> primitives = new List<glTFLoader.Schema.MeshPrimitive>(MeshPrimitives.Count);
+            List<float> weights = new List<float>();
             // Loops through each wrapped mesh primitive within the mesh and converts them to mesh primitives, as well as updating the
             // indices in the lists
             foreach (Runtime.MeshPrimitive gPrimitive in MeshPrimitives)
             {
                 glTFLoader.Schema.MeshPrimitive mPrimitive = gPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset, true, false, false);
+                if (gPrimitive.MorphTargets != null && gPrimitive.MorphTargets.Count() > 0)
+                {
+                    List<Dictionary<string, int> > morphTargetAttributes = gPrimitive.GetMorphTargets(bufferViews, accessors, ref buffer, geometryData, ref weights, buffer_index, buffer_offset);
+                    mPrimitive.Targets = morphTargetAttributes.ToArray();
+                }
                 primitives.Add(mPrimitive);
             }
             if (Name != null)
@@ -82,6 +88,10 @@ namespace AssetGenerator.Runtime
             if (MeshPrimitives != null && primitives.Count > 0)
             {
                 mesh.Primitives = primitives.ToArray();
+            }
+            if (weights.Count > 0)
+            {
+                mesh.Weights = weights.ToArray();
             }
 
             return mesh;

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -14,6 +14,7 @@ namespace AssetGenerator.Runtime
     /// </summary>
     public class MeshPrimitive
     {
+        
         /// <summary>
         /// Material for the mesh primitive
         /// </summary>
@@ -44,7 +45,7 @@ namespace AssetGenerator.Runtime
         /// </summary>
         public glTFLoader.Schema.MeshPrimitive.ModeEnum Mode { get; set; }
 
-
+       
         /// <summary>
         /// Computes and returns the minimum and maximum positions for the mesh primitive.
         /// </summary>
@@ -219,11 +220,11 @@ namespace AssetGenerator.Runtime
                 BufferView = bufferview_index,
                 Name = name,
             };
-            if (min.Count() > 0)
+            if (min != null && min.Count() > 0)
             {
                 accessor.Min = min;
             };
-            if (max.Count() > 0)
+            if (max != null && max.Count() > 0)
             {
                 accessor.Max = max;
             }

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -29,15 +29,21 @@ namespace AssetGenerator.Runtime
         /// </summary>
         public List<Vector3> Normals { get; set; }
 
+        public List<Vector3> Tangents { get; set; }
+
         /// <summary>
         /// List of texture coordinate sets (as lists of Vector2) 
         /// </summary>
         public List<List<Vector2>> TextureCoordSets { get; set; }
 
+        public List<MeshPrimitive> MorphTargets { get; set; }
+        public float morphTargetWeight { get; set; }
+
         /// <summary>
         /// Sets the type of primitive to render.
         /// </summary>
         public glTFLoader.Schema.MeshPrimitive.ModeEnum Mode { get; set; }
+
 
         /// <summary>
         /// Computes and returns the minimum and maximum positions for the mesh primitive.
@@ -240,6 +246,7 @@ namespace AssetGenerator.Runtime
             
             return accessor;
         }
+        
         /// <summary>
         /// Converts the wrapped mesh primitive into gltf mesh primitives, as well as updates the indices in the lists
         /// </summary>
@@ -370,8 +377,83 @@ namespace AssetGenerator.Runtime
                 materials.Add(nMaterial);
                 mPrimitive.Material = materials.Count() - 1;
             }
+            
 
             return mPrimitive;
+
+        }
+        /// <summary>
+        /// Converts the morph target list of dictionaries into Morph Target
+        /// </summary>
+        public List<Dictionary<string, int>> GetMorphTargets(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, ref glTFLoader.Schema.Buffer buffer, Data geometryData, ref List<float> weights,  int buffer_index, int buffer_offset)
+        {
+            List<Dictionary<string, int>> morphTargetDicts = new List<Dictionary<string, int>>();
+            if (MorphTargets != null)
+            {
+
+                foreach(MeshPrimitive morphTarget in MorphTargets)
+                {
+                    Dictionary<string, int> morphTargetAttributes = new Dictionary<string, int>();
+                    
+
+                    if (morphTarget.Positions != null && morphTarget.Positions.Count > 0)
+                    {
+                        if (morphTarget.Positions != null)
+                        {
+                            //Create BufferView for the position
+                            int byteLength = sizeof(float) * 3 * morphTarget.Positions.Count();
+                            
+                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer_offset);
+
+                            bufferViews.Add(bufferView);
+                            int bufferview_index = bufferViews.Count() - 1;
+
+                            // Create an accessor for the bufferView
+                            glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Positions.Count(), "Positions Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                            buffer.ByteLength += byteLength;
+
+
+                            //  bufferView.ByteLength += byteLength;
+                            accessors.Add(accessor);
+                            geometryData.Writer.Write(morphTarget.Positions.ToArray());
+                            morphTargetAttributes.Add("POSITION", accessors.Count() - 1);
+                        }
+                    }
+                    if (morphTarget.Normals != null && morphTarget.Normals.Count > 0)
+                    {
+                        if (morphTarget.Normals != null)
+                        {
+                            // Create BufferView
+                            int byteLength = sizeof(float) * 3 * morphTarget.Normals.Count();
+                            // Create a bufferView
+                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
+                            //get the max and min values
+                            
+
+                            bufferViews.Add(bufferView);
+                            int bufferview_index = bufferViews.Count() - 1;
+
+                            // Create an accessor for the bufferView
+                            glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Normals.Count(), "Normals Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+
+                            buffer.ByteLength += byteLength;
+                            accessors.Add(accessor);
+                            geometryData.Writer.Write(morphTarget.Normals.ToArray());
+                            morphTargetAttributes.Add("NORMAL", accessors.Count() - 1);
+                        }
+                    }
+                    if (morphTarget.Tangents != null && morphTarget.Tangents.Count > 0)
+                    {
+                        //not implemented...
+
+                    }
+
+                    morphTargetDicts.Add(new Dictionary<string, int> (morphTargetAttributes));
+                    weights.Add(morphTargetWeight);
+                }
+            }
+
+            return morphTargetDicts;
 
         }
     }


### PR DESCRIPTION
This adds morph target support to the runtime layer.  IT uses multiple mesh primitives as containers for other morph targets, assuming the positions and normals are associated with the same root mesh primitive