### PR TITLE
fix multiple primitives bug

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -85,11 +85,11 @@ namespace AssetGenerator.Runtime.Tests
             List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
-            int buffer_index = 0, buffer_offset = 0;
+            int buffer_index = 0;
             glTFLoader.Schema.Buffer bufer = new glTFLoader.Schema.Buffer();
 
             MeshPrimitive meshPrim = new MeshPrimitive();
-            meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset, true, false, false);
+            meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, true, false, false);
         }
 
         [TestMethod()]
@@ -124,7 +124,7 @@ namespace AssetGenerator.Runtime.Tests
             List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
-            int buffer_index = 0, buffer_offset = 0;
+            int buffer_index = 0;
             
 
             MeshPrimitive meshPrim = new MeshPrimitive
@@ -144,7 +144,7 @@ namespace AssetGenerator.Runtime.Tests
             meshPrim.morphTargetWeight = 0;
             Mesh mesh = new Mesh();
             mesh.AddPrimitive(meshPrim);
-            glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset);
+            glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index);
             Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
             Assert.IsTrue(m.Weights.Count() > 0);
         }

--- a/Source/AssetGeneratorTests/Runtime/MeshTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshTests.cs
@@ -39,9 +39,8 @@ namespace AssetGenerator.Runtime.Tests
             Mesh m = new Mesh();
 
             int buffer_index = 0;
-            int buffer_offset = 0;
 
-            m.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset);
+            m.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index);
         }
     }
 }

--- a/Source/Runtime/GLTF.cs
+++ b/Source/Runtime/GLTF.cs
@@ -51,7 +51,6 @@ namespace AssetGenerator.Runtime
                 Uri = geometryData.Name,
             };
             int buffer_index = 0;
-            int buffer_offset = 0;
 
 
             // for each scene, create a node for each mesh and compute the indices for the scene object
@@ -63,7 +62,7 @@ namespace AssetGenerator.Runtime
                 {
                     Runtime.Mesh gMesh = gscene.Meshes[mesh_index];
 
-                    glTFLoader.Schema.Mesh m = gMesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref gBuffer, buffer_index, buffer_offset);
+                    glTFLoader.Schema.Mesh m = gMesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref gBuffer, buffer_index);
                     meshes.Add(m);
 
                     glTFLoader.Schema.Node node = new glTFLoader.Schema.Node

--- a/Source/Runtime/Mesh.cs
+++ b/Source/Runtime/Mesh.cs
@@ -64,7 +64,7 @@ namespace AssetGenerator.Runtime
         /// <param name="geometryData"></param>
         /// <param name="gBuffer"></param>
         /// <returns>glTF Mesh object</returns>
-        public glTFLoader.Schema.Mesh ConvertToMesh(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int buffer_index, int buffer_offset)
+        public glTFLoader.Schema.Mesh ConvertToMesh(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int buffer_index)
         {
             glTFLoader.Schema.Mesh mesh = new glTFLoader.Schema.Mesh();
             List<glTFLoader.Schema.MeshPrimitive> primitives = new List<glTFLoader.Schema.MeshPrimitive>(MeshPrimitives.Count);
@@ -73,10 +73,10 @@ namespace AssetGenerator.Runtime
             // indices in the lists
             foreach (Runtime.MeshPrimitive gPrimitive in MeshPrimitives)
             {
-                glTFLoader.Schema.MeshPrimitive mPrimitive = gPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, buffer_offset, true, false, false);
+                glTFLoader.Schema.MeshPrimitive mPrimitive = gPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, true, false, false);
                 if (gPrimitive.MorphTargets != null && gPrimitive.MorphTargets.Count() > 0)
                 {
-                    List<Dictionary<string, int> > morphTargetAttributes = gPrimitive.GetMorphTargets(bufferViews, accessors, ref buffer, geometryData, ref weights, buffer_index, buffer_offset);
+                    List<Dictionary<string, int> > morphTargetAttributes = gPrimitive.GetMorphTargets(bufferViews, accessors, ref buffer, geometryData, ref weights, buffer_index);
                     mPrimitive.Targets = morphTargetAttributes.ToArray();
                 }
                 primitives.Add(mPrimitive);

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -260,7 +260,7 @@ namespace AssetGenerator.Runtime
         /// <param name="geometryData"></param>
         /// <param name="gBuffer"></param>
         /// <returns>MeshPrimitive instance</returns>
-        public glTFLoader.Schema.MeshPrimitive ConvertToMeshPrimitive(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int buffer_index, int buffer_offset, bool minMaxRangePositions, bool minMaxRangeNormals, bool minMaxRangeTextureCoords)
+        public glTFLoader.Schema.MeshPrimitive ConvertToMeshPrimitive(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int buffer_index, bool minMaxRangePositions, bool minMaxRangeNormals, bool minMaxRangeTextureCoords)
         {
             Dictionary<string, int> attributes = new Dictionary<string, int>();
 
@@ -279,7 +279,8 @@ namespace AssetGenerator.Runtime
                 }
                 
 
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer_offset);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer.ByteLength);
+                
                 
                 bufferViews.Add(bufferView);
                 int bufferview_index = bufferViews.Count() - 1;
@@ -302,6 +303,7 @@ namespace AssetGenerator.Runtime
                 int byteLength = sizeof(float) * 3 * Normals.Count();
                 // Create a bufferView
                 glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
+                
                 //get the max and min values
                 float[] min = new float[] { };
                 float[] max = new float[] { };
@@ -345,6 +347,7 @@ namespace AssetGenerator.Runtime
 
                     // Create a bufferView
                     glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Texture Coords " + (i + 1), byteLength, buffer.ByteLength);
+                    
                     float[] min = new float[] { };
                     float[] max = new float[] { };
                     if (minMaxRangeTextureCoords)
@@ -366,6 +369,7 @@ namespace AssetGenerator.Runtime
                     geometryData.Writer.Write(textureCoordSet.ToArray());
                     attributes.Add("TEXCOORD_" + i, accessors.Count() - 1);
 
+
                 }
             }
             glTFLoader.Schema.MeshPrimitive mPrimitive = new glTFLoader.Schema.MeshPrimitive
@@ -386,7 +390,7 @@ namespace AssetGenerator.Runtime
         /// <summary>
         /// Converts the morph target list of dictionaries into Morph Target
         /// </summary>
-        public List<Dictionary<string, int>> GetMorphTargets(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, ref glTFLoader.Schema.Buffer buffer, Data geometryData, ref List<float> weights,  int buffer_index, int buffer_offset)
+        public List<Dictionary<string, int>> GetMorphTargets(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, ref glTFLoader.Schema.Buffer buffer, Data geometryData, ref List<float> weights,  int buffer_index)
         {
             List<Dictionary<string, int>> morphTargetDicts = new List<Dictionary<string, int>>();
             if (MorphTargets != null)
@@ -404,7 +408,7 @@ namespace AssetGenerator.Runtime
                             //Create BufferView for the position
                             int byteLength = sizeof(float) * 3 * morphTarget.Positions.Count();
                             
-                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer_offset);
+                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer.ByteLength);
 
                             bufferViews.Add(bufferView);
                             int bufferview_index = bufferViews.Count() - 1;


### PR DESCRIPTION
This PR should fix the multiple primitives bug. It was not calculating the buffer offsets correctly.  Now it uses the running count of the bufferlength of the buffer as the offset instead of a variable.