### PR TITLE
Move the model directory before deleting it, to prevent lockouts

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -39,12 +39,14 @@ namespace AssetGenerator
 
                 // Delete any preexisting files in the output directories, then create those directories if needed
                 var assetFolder = Path.Combine(executingAssemblyFolder, test.ToString());
+                var trashFolder = Path.Combine(executingAssemblyFolder, "Delete");
                 bool tryAgain = true;
                 while (tryAgain)
                 {
                     try
                     {
-                        Directory.Delete(assetFolder, true);
+                        Directory.Move(assetFolder, trashFolder);
+                        Directory.Delete(trashFolder, true);
                         tryAgain = false;
                     }
                     catch (DirectoryNotFoundException)


### PR DESCRIPTION
Sometimes the app would crash when run. I think this was due to a file lockout caused by deleting the old model folder before a new folder was created. Doing this failed to create a model folder silently if the user had the folder open (or something else delayed the delete).

Fix for issue #102 