### PR TITLE
convert to ushort or byte when normalized booleans enabled for mesh primitive

### DIFF
--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -18,7 +18,7 @@ namespace AssetGenerator.Runtime
         public enum TextureCoordsAccessorModes { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
 
         public ColorAccessorModes ColorAccessorMode { get; set; }
-        public TextureCoordsAccessorModes textureCoordsAccessorMode { get; set; }
+        public TextureCoordsAccessorModes TextureCoordsAccessorMode { get; set; }
 
         /// <summary>
         /// Material for the mesh primitive
@@ -492,11 +492,11 @@ namespace AssetGenerator.Runtime
                     glTFLoader.Schema.Accessor accessor;
 
                     // Create an accessor for the bufferView
-                    if (textureCoordsAccessorMode == TextureCoordsAccessorModes.NORMALIZED_UBYTE)
+                    if (TextureCoordsAccessorMode == TextureCoordsAccessorModes.NORMALIZED_UBYTE)
                     {
                         accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, true);
                     }
-                    else if (textureCoordsAccessorMode == TextureCoordsAccessorModes.NORMALIZED_USHORT)
+                    else if (TextureCoordsAccessorMode == TextureCoordsAccessorModes.NORMALIZED_USHORT)
                     {
                         accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, true);
 

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -510,7 +510,12 @@ namespace AssetGenerator.Runtime
                             }
                         }
                     }
-                    geometryData.Writer.Write(textureCoordSet.ToArray());
+                    else
+                    {
+                        geometryData.Writer.Write(textureCoordSetArr);
+
+                    }
+                    
                     attributes.Add("TEXCOORD_" + i, accessors.Count() - 1);
 
 

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -568,7 +568,6 @@ namespace AssetGenerator.Runtime
                     }
                     if (morphTarget.Normals != null && morphTarget.Normals.Count > 0)
                     {
-                        // Create BufferView
                         int byteLength = sizeof(float) * 3 * morphTarget.Normals.Count();
                         // Create a bufferView
                         glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
@@ -588,8 +587,6 @@ namespace AssetGenerator.Runtime
                     }
                     if (morphTarget.Tangents != null && morphTarget.Tangents.Count > 0)
                     {
-                        //not implemented...
-                        // Create BufferView
                         int byteLength = sizeof(float) * 3 * morphTarget.Tangents.Count();
                         // Create a bufferView
                         glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Tangents", byteLength, buffer.ByteLength);

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -14,7 +14,13 @@ namespace AssetGenerator.Runtime
     /// </summary>
     public class MeshPrimitive
     {
+        /// <summary>
+        /// Specifies which mode to use when defining the color accessor (Float is the default value)
+        /// </summary>
         public enum ColorAccessorModes { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE};
+        /// <summary>
+        /// Specifies which mode to use hwen defining the texture coordinates accessor (Float is the default value)
+        /// </summary>
         public enum TextureCoordsAccessorModes { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
 
         public ColorAccessorModes ColorAccessorMode { get; set; }


### PR DESCRIPTION
`Runtime.MeshPrimitive` has four properties for controlling how the accessors store binary data for Colors and Texture Coordinates.

Setting `NormalizeColorCoords` to `true` and setting the `ColorComponentType` will use this value when creating the accessor and write in the appropriate format.  The same happens for `NormalizeTextureCoords` and `TextureCoordsComponentType`