### PR TITLE
Fix the color implementation in MeshPrimitive

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -147,6 +147,21 @@ namespace AssetGenerator.Runtime.Tests
             Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
             Assert.IsTrue(m.Weights.Count() > 0);
         }
+        [TestMethod()]
+        public void ColorAttributeEnumTest()
+        {
+            MeshPrimitive meshPrimitive = new MeshPrimitive();
+
+            meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.FLOAT | MeshPrimitive.ColorAccessorModeEnum.VEC3;
+            Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.FLOAT | MeshPrimitive.ColorAccessorModeEnum.VEC3);
+
+            meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4;
+            Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4);
+
+            
+
+
+        }
 
     }
 }

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -62,7 +62,6 @@ namespace AssetGenerator.Runtime.Tests
                 }
 
             };
-
             MeshPrimitive meshPrim = new MeshPrimitive();
             meshPrim.TextureCoordSets = triangleTextureCoordSets;
             List<Vector2[]> minMaxTextureCoordSets = meshPrim.GetMinMaxTextureCoords();
@@ -73,7 +72,6 @@ namespace AssetGenerator.Runtime.Tests
             Assert.AreEqual(minMaxTextureCoordSets[1][0], new Vector2(0.5f, 0.0f));
             Assert.AreEqual(minMaxTextureCoordSets[1][1], new Vector2(1.0f, 1.0f));
         }
-
         [TestMethod()]
         public void ConvertToMeshPrimitiveTest()
         {
@@ -90,7 +88,6 @@ namespace AssetGenerator.Runtime.Tests
             MeshPrimitive meshPrim = new MeshPrimitive();
             meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, true, false, false, false);
         }
-
         [TestMethod()]
         public void GetMorphTargetsTest()
         {
@@ -100,21 +97,18 @@ namespace AssetGenerator.Runtime.Tests
                 new Vector3(-1.0f, 0.0f, 0.0f),
                 new Vector3(0.0f, 1.0f, 0.0f),
             };
-
             var positions2 = new List<Vector3>
             {
                 new Vector3(1.0f, 0.0f, 0.0f),
                 new Vector3(-1.0f, 0.0f, 0.0f),
                 new Vector3(1.0f, 1.0f, 0.0f),
             };
-
             var normals = new List<Vector3>
             {
                 new Vector3(0.0f, 0.0f, -1.0f),
                 new Vector3(0.0f, 0.0f, -1.0f),
                 new Vector3(0.0f, 0.0f, -1.0f)
             };
-
             List<glTFLoader.Schema.BufferView> bufferViews = new List<glTFLoader.Schema.BufferView>();
             List<glTFLoader.Schema.Accessor> accessors = new List<glTFLoader.Schema.Accessor>();
             List<glTFLoader.Schema.Texture> textures = new List<glTFLoader.Schema.Texture>();
@@ -124,8 +118,6 @@ namespace AssetGenerator.Runtime.Tests
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
             int buffer_index = 0;
-
-
             MeshPrimitive meshPrim = new MeshPrimitive
             {
                 Positions = positions,
@@ -157,11 +149,6 @@ namespace AssetGenerator.Runtime.Tests
 
             meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4;
             Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4);
-
-            
-
-
         }
-
     }
 }

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -86,7 +86,6 @@ namespace AssetGenerator.Runtime.Tests
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
             int buffer_index = 0;
-            glTFLoader.Schema.Buffer bufer = new glTFLoader.Schema.Buffer();
 
             MeshPrimitive meshPrim = new MeshPrimitive();
             meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, true, false, false, false);
@@ -125,7 +124,7 @@ namespace AssetGenerator.Runtime.Tests
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
             int buffer_index = 0;
-            
+
 
             MeshPrimitive meshPrim = new MeshPrimitive
             {
@@ -148,5 +147,6 @@ namespace AssetGenerator.Runtime.Tests
             Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
             Assert.IsTrue(m.Weights.Count() > 0);
         }
+
     }
 }

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -22,10 +22,10 @@ namespace AssetGenerator.Runtime
         /// <summary>
         /// Specifies which mode to use when defining the texture coordinates accessor (Float is the default value)
         /// </summary>
-        public enum TextureCoordsAccessorModes { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
+        public enum TextureCoordsAccessorModeEnum { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
 
         public ColorAccessorModeEnum ColorAccessorMode { get; set; }
-        public TextureCoordsAccessorModes TextureCoordsAccessorMode { get; set; }
+        public TextureCoordsAccessorModeEnum TextureCoordsAccessorMode { get; set; }
 
         /// <summary>
         /// Material for the mesh primitive
@@ -300,11 +300,11 @@ namespace AssetGenerator.Runtime
         {
             Dictionary<string, int> attributes = new Dictionary<string, int>();
 
-            Dictionary<TextureCoordsAccessorModes, glTFLoader.Schema.Accessor.ComponentTypeEnum> textureCoordsAccessorTypeMapping = new Dictionary<TextureCoordsAccessorModes, glTFLoader.Schema.Accessor.ComponentTypeEnum>()
+            Dictionary<TextureCoordsAccessorModeEnum, glTFLoader.Schema.Accessor.ComponentTypeEnum> textureCoordsAccessorTypeMapping = new Dictionary<TextureCoordsAccessorModeEnum, glTFLoader.Schema.Accessor.ComponentTypeEnum>()
             {
-                { TextureCoordsAccessorModes.FLOAT, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT },
-                { TextureCoordsAccessorModes.NORMALIZED_UBYTE, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE },
-                { TextureCoordsAccessorModes.NORMALIZED_USHORT, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT },
+                { TextureCoordsAccessorModeEnum.FLOAT, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT },
+                { TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE },
+                { TextureCoordsAccessorModeEnum.NORMALIZED_USHORT, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT },
 
             };
 
@@ -406,12 +406,14 @@ namespace AssetGenerator.Runtime
             {                
                 int byteLength;
                 glTFLoader.Schema.Accessor.ComponentTypeEnum colorAccessorComponentType;
+                glTFLoader.Schema.Accessor.TypeEnum colorAccessorType;
 
                 switch (ColorAccessorMode)
                 {
                     case ColorAccessorModeEnum.FLOAT | ColorAccessorModeEnum.VEC3:
                         byteLength = sizeof(float) * 3 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC3;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(color.x);
@@ -422,6 +424,7 @@ namespace AssetGenerator.Runtime
                     case ColorAccessorModeEnum.FLOAT | ColorAccessorModeEnum.VEC4:
                         byteLength = sizeof(float) * 4 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC4;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(color.x);
@@ -433,6 +436,7 @@ namespace AssetGenerator.Runtime
                     case ColorAccessorModeEnum.NORMALIZED_UBYTE | ColorAccessorModeEnum.VEC3:
                         byteLength = sizeof(float) * 3 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC3;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(Convert.ToByte(color.x));
@@ -443,6 +447,7 @@ namespace AssetGenerator.Runtime
                     case ColorAccessorModeEnum.NORMALIZED_UBYTE | ColorAccessorModeEnum.VEC4:
                         byteLength = sizeof(float) * 4 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC4;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(Convert.ToByte(color.x));
@@ -454,6 +459,7 @@ namespace AssetGenerator.Runtime
                     case ColorAccessorModeEnum.NORMALIZED_USHORT | ColorAccessorModeEnum.VEC3:
                         byteLength = sizeof(float) * 3 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC3;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(Convert.ToUInt16(color.x));
@@ -464,6 +470,7 @@ namespace AssetGenerator.Runtime
                     case ColorAccessorModeEnum.NORMALIZED_USHORT | ColorAccessorModeEnum.VEC4:
                         byteLength = sizeof(float) * 4 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC4;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(Convert.ToUInt16(color.x));
@@ -475,6 +482,7 @@ namespace AssetGenerator.Runtime
                     default: // Defaults to Float/VEC4
                         byteLength = sizeof(float) * 4 * Colors.Count();
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
+                        colorAccessorType = glTFLoader.Schema.Accessor.TypeEnum.VEC4;
                         foreach (Vector4 color in Colors)
                         {
                             geometryData.Writer.Write(color.x);
@@ -494,7 +502,7 @@ namespace AssetGenerator.Runtime
                 // Create an accessor for the bufferView
                 // we normalize if the color accessor mode is not set to FLOAT
                 bool normalized = (ColorAccessorMode & ColorAccessorModeEnum.FLOAT) != ColorAccessorModeEnum.FLOAT;
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, normalized);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, colorAccessorType, normalized);
 
                 accessors.Add(accessor);
 
@@ -530,10 +538,27 @@ namespace AssetGenerator.Runtime
                     
                     bufferViews.Add(bufferView);
                     int bufferview_index = bufferViews.Count() - 1;
+                    glTFLoader.Schema.Accessor accessor;
                     // we normalize only if the texture cood accessor type is not float
-                    bool normalized = textureCoordsAccessorTypeMapping[TextureCoordsAccessorMode] != glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
-                    glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, textureCoordsAccessorTypeMapping[TextureCoordsAccessorMode], textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                    bool normalized = TextureCoordsAccessorMode != TextureCoordsAccessorModeEnum.FLOAT;
+                    switch(TextureCoordsAccessorMode)
+                    {
+                        case TextureCoordsAccessorModeEnum.FLOAT:
+                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            break;
+                        case TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE:
+                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            break;
+                        case TextureCoordsAccessorModeEnum.NORMALIZED_USHORT:
+                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            break;
+                        default: // Default to Float
+                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            break;
 
+
+                    }
+                   
                     buffer.ByteLength += byteLength;
                     accessors.Add(accessor);
                     Vector2[] textureCoordSetArr = textureCoordSet.ToArray();

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-
-
-
 namespace AssetGenerator.Runtime
 {
     /// <summary>
@@ -51,7 +48,6 @@ namespace AssetGenerator.Runtime
         /// List of colors for the mesh primitive
         /// </summary>
         public List<Vector4> Colors { get; set; }
-
 
         /// <summary>
         /// List of texture coordinate sets (as lists of Vector2) 
@@ -139,7 +135,6 @@ namespace AssetGenerator.Runtime
             }
             Vector2[] results = { minVal, maxVal };
             return results;
-
         }
         /// <summary>
         /// Computes the minimum and maximum values of a list of Vector3
@@ -173,7 +168,6 @@ namespace AssetGenerator.Runtime
             }
             Vector3[] results = { minVal, maxVal };
             return results;
-
         }
         /// <summary>
         /// Computes the minimum and maximum values of a list of Vector4
@@ -229,7 +223,6 @@ namespace AssetGenerator.Runtime
                 ByteOffset = byteOffset,
                 Buffer = buffer_index
             };
-
             return bufferView;
         }
         /// <summary>
@@ -279,11 +272,9 @@ namespace AssetGenerator.Runtime
             if (normalized.HasValue)
             {
                 accessor.Normalized = normalized.Value;
-            }
-            
+            }   
             return accessor;
         }
-        
         /// <summary>
         /// Converts the wrapped mesh primitive into gltf mesh primitives, as well as updates the indices in the lists
         /// </summary>
@@ -313,11 +304,7 @@ namespace AssetGenerator.Runtime
                     max = new[] { minMaxPositions[0].x, minMaxPositions[0].y, minMaxPositions[0].z };
                     min = new[] { minMaxPositions[1].x, minMaxPositions[1].y, minMaxPositions[1].z };
                 }
-                
-
                 glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer.ByteLength);
-                
-                
                 bufferViews.Add(bufferView);
                 int bufferview_index = bufferViews.Count() - 1;
 
@@ -330,8 +317,6 @@ namespace AssetGenerator.Runtime
                 accessors.Add(accessor);
                 geometryData.Writer.Write(Positions.ToArray());
                 attributes.Add("POSITION", accessors.Count() - 1);
-
-
             }
             if (Normals != null)
             {
@@ -351,8 +336,6 @@ namespace AssetGenerator.Runtime
                     max = new[] { minMaxNormals[0].x, minMaxNormals[0].y, minMaxNormals[0].z };
                     min = new[] { minMaxNormals[1].x, minMaxNormals[1].y, minMaxNormals[1].z };
                 }
-                
-
                 bufferViews.Add(bufferView);
                 int bufferview_index = bufferViews.Count() - 1;
 
@@ -382,7 +365,6 @@ namespace AssetGenerator.Runtime
                     max = new[] { minMaxTangents[0].x, minMaxTangents[0].y, minMaxTangents[0].z, minMaxTangents[0].w };
                     min = new[] { minMaxTangents[1].x, minMaxTangents[1].y, minMaxTangents[1].z, minMaxTangents[1].w };
                 }
-
 
                 bufferViews.Add(bufferView);
                 int bufferview_index = bufferViews.Count() - 1;
@@ -484,7 +466,6 @@ namespace AssetGenerator.Runtime
                         }
                         break;
                 }
-                
                 // Create BufferView
                 glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Colors", byteLength, buffer.ByteLength);
                 bufferViews.Add(bufferView);
@@ -495,12 +476,9 @@ namespace AssetGenerator.Runtime
                 // we normalize if the color accessor mode is not set to FLOAT
                 bool normalized = (ColorAccessorMode & ColorAccessorModeEnum.FLOAT) != ColorAccessorModeEnum.FLOAT;
                 glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, colorAccessorType, normalized);
-
                 accessors.Add(accessor);
-
                 attributes.Add("COLOR_0", accessors.Count() - 1);
             }
-
             if (TextureCoordSets != null)
             {
                 //get the max and min values
@@ -510,7 +488,6 @@ namespace AssetGenerator.Runtime
                 {
                     minMaxTextureCoords = GetMinMaxTextureCoords();
                 }
-
                 for (int i = 0; i < TextureCoordSets.Count; ++i)
                 {
                     List<Vector2> textureCoordSet = TextureCoordSets[i];
@@ -547,10 +524,7 @@ namespace AssetGenerator.Runtime
                         default: // Default to Float
                             accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
                             break;
-
-
                     }
-                   
                     buffer.ByteLength += byteLength;
                     accessors.Add(accessor);
                     Vector2[] textureCoordSetArr = textureCoordSet.ToArray();
@@ -578,7 +552,6 @@ namespace AssetGenerator.Runtime
                     {
                         geometryData.Writer.Write(textureCoordSetArr);
                     }
-                    
                     attributes.Add("TEXCOORD_" + i, accessors.Count() - 1);
                 }
             }
@@ -592,7 +565,6 @@ namespace AssetGenerator.Runtime
                 materials.Add(nMaterial);
                 mPrimitive.Material = materials.Count() - 1;
             }
-            
             return mPrimitive;
         }
         /// <summary>
@@ -603,7 +575,6 @@ namespace AssetGenerator.Runtime
             List<Dictionary<string, int>> morphTargetDicts = new List<Dictionary<string, int>>();
             if (MorphTargets != null)
             {
-
                 foreach(MeshPrimitive morphTarget in MorphTargets)
                 {
                     Dictionary<string, int> morphTargetAttributes = new Dictionary<string, int>();
@@ -624,9 +595,6 @@ namespace AssetGenerator.Runtime
                             // Create an accessor for the bufferView
                             glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Positions.Count(), "Positions Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
                             buffer.ByteLength += byteLength;
-
-
-                            //  bufferView.ByteLength += byteLength;
                             accessors.Add(accessor);
                             geometryData.Writer.Write(morphTarget.Positions.ToArray());
                             morphTargetAttributes.Add("POSITION", accessors.Count() - 1);
@@ -638,7 +606,6 @@ namespace AssetGenerator.Runtime
                         // Create a bufferView
                         glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
                         //get the max and min values
-                            
 
                         bufferViews.Add(bufferView);
                         int bufferview_index = bufferViews.Count() - 1;
@@ -658,7 +625,6 @@ namespace AssetGenerator.Runtime
                         glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Tangents", byteLength, buffer.ByteLength);
                         //get the max and min values
 
-
                         bufferViews.Add(bufferView);
                         int bufferview_index = bufferViews.Count() - 1;
 
@@ -670,16 +636,11 @@ namespace AssetGenerator.Runtime
                         geometryData.Writer.Write(morphTarget.Tangents.ToArray());
                         morphTargetAttributes.Add("TANGENT", accessors.Count() - 1);
                     }
-
                     morphTargetDicts.Add(new Dictionary<string, int> (morphTargetAttributes));
                     weights.Add(morphTargetWeight);
                 }
             }
-
             return morphTargetDicts;
-
         }
     }
-    
-    
 }

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -300,14 +300,6 @@ namespace AssetGenerator.Runtime
         {
             Dictionary<string, int> attributes = new Dictionary<string, int>();
 
-            Dictionary<TextureCoordsAccessorModeEnum, glTFLoader.Schema.Accessor.ComponentTypeEnum> textureCoordsAccessorTypeMapping = new Dictionary<TextureCoordsAccessorModeEnum, glTFLoader.Schema.Accessor.ComponentTypeEnum>()
-            {
-                { TextureCoordsAccessorModeEnum.FLOAT, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT },
-                { TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE },
-                { TextureCoordsAccessorModeEnum.NORMALIZED_USHORT, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT },
-
-            };
-
             if (Positions != null)
             {
                 //Create BufferView for the position


### PR DESCRIPTION
**Changes:**

The `Color` attribute of `Runtime.MeshPrimitive` is now defined as `Vector4` instead of `Vector3`.

The color enum has been renamed from `ColorAccessorModes` to `ColorAccessorModeEnum` and has a Flag Attribute applied.  

i.e. To specify Float Vec4:
`meshPrimitive.ColorAccessorMode = Runtime.MeshPrimitive.ColorAccessorModeEnum.FLOAT | Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC4;`

And to specify ubyte Vec3:
`meshPrimitive.ColorAccessorMode = Runtime.MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC3;`


`TextureCoordsAccessorModes` has also been renamed to `TextureCoordsAccessorModeEnum` to be consistent with the Color enum.

A unit test has been added to test the flags of the `ColorAccessorEnum`