### PR TITLE
Add indices support to Runtime.MeshPrimitive

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -83,10 +83,10 @@ namespace AssetGenerator.Runtime.Tests
             List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
-            int buffer_index = 0;
+            int bufferIndex = 0;
 
             MeshPrimitive meshPrim = new MeshPrimitive();
-            meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, true, false, false, false);
+            meshPrim.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, bufferIndex, true, false, false, false);
         }
         [TestMethod()]
         public void GetMorphTargetsTest()
@@ -117,7 +117,7 @@ namespace AssetGenerator.Runtime.Tests
             List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
-            int buffer_index = 0;
+            int bufferIndex = 0;
             MeshPrimitive meshPrim = new MeshPrimitive
             {
                 Positions = positions,
@@ -135,7 +135,7 @@ namespace AssetGenerator.Runtime.Tests
             meshPrim.morphTargetWeight = 0;
             Mesh mesh = new Mesh();
             mesh.AddPrimitive(meshPrim);
-            glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index);
+            glTFLoader.Schema.Mesh m = mesh.ConvertToMesh(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, bufferIndex);
             Assert.IsTrue(m.Primitives[0].Targets.Count() > 0);
             Assert.IsTrue(m.Weights.Count() > 0);
         }
@@ -162,7 +162,7 @@ namespace AssetGenerator.Runtime.Tests
             List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
             glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
             Data geometryData = new Data("test.bin");
-            int buffer_index = 0;
+            int bufferIndex = 0;
 
             MeshPrimitive meshPrimitive = new MeshPrimitive();
             meshPrimitive.Positions = new List<Vector3>
@@ -193,7 +193,7 @@ namespace AssetGenerator.Runtime.Tests
                     new Vector2(0.0f, 0.0f)
                 }
             };
-            glTFLoader.Schema.MeshPrimitive sMeshPrimitive = meshPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, false, false, false, false);
+            glTFLoader.Schema.MeshPrimitive sMeshPrimitive = meshPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, bufferIndex, false, false, false, false);
             Assert.AreEqual(sMeshPrimitive.Indices, 2); // indices is third bufferview, or index 2
             
             

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -195,6 +195,7 @@ namespace AssetGenerator.Runtime.Tests
             };
             glTFLoader.Schema.MeshPrimitive sMeshPrimitive = meshPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, bufferIndex, false, false, false, false);
             Assert.AreEqual(sMeshPrimitive.Indices, 2); // indices is third bufferview, or index 2
+            Assert.AreEqual(accessors[2].Count, 6); // should be siz index values
             
             
         }

--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -150,5 +150,53 @@ namespace AssetGenerator.Runtime.Tests
             meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4;
             Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4);
         }
+
+        [TestMethod()]
+        public void IndicesTest()
+        {
+            List<glTFLoader.Schema.BufferView> bufferViews = new List<glTFLoader.Schema.BufferView>();
+            List<glTFLoader.Schema.Accessor> accessors = new List<glTFLoader.Schema.Accessor>();
+            List<glTFLoader.Schema.Texture> textures = new List<glTFLoader.Schema.Texture>();
+            List<glTFLoader.Schema.Material> materials = new List<glTFLoader.Schema.Material>();
+            List<glTFLoader.Schema.Sampler> samplers = new List<glTFLoader.Schema.Sampler>();
+            List<glTFLoader.Schema.Image> images = new List<glTFLoader.Schema.Image>();
+            glTFLoader.Schema.Buffer buffer = new glTFLoader.Schema.Buffer();
+            Data geometryData = new Data("test.bin");
+            int buffer_index = 0;
+
+            MeshPrimitive meshPrimitive = new MeshPrimitive();
+            meshPrimitive.Positions = new List<Vector3>
+            {
+                new Vector3(0.0f, 0.0f, 0.0f),
+                new Vector3(-1.0f, 0.0f, 0.0f),
+                new Vector3(-1.0f, 1.0f, 0.0f),
+                new Vector3(0.0f, 1.0f, 0.0f)
+            };
+            meshPrimitive.Normals = new List<Vector3>
+            {
+                new Vector3(0.0f, 0.0f, -1.0f),
+                new Vector3(0.0f, 0.0f, -1.0f),
+                new Vector3(0.0f, 0.0f, -1.0f),
+                new Vector3(0.0f, 0.0f, -1.0f)
+            };
+            meshPrimitive.Indices = new List<int>
+            {
+                0, 1, 3, 1, 2, 3
+            };
+            meshPrimitive.TextureCoordSets = new List<List<Vector2>>
+            {
+                new List<Vector2>
+                {
+                    new Vector2(0.0f, 1.0f),
+                    new Vector2(1.0f, 1.0f),
+                    new Vector2(1.0f, 0.0f),
+                    new Vector2(0.0f, 0.0f)
+                }
+            };
+            glTFLoader.Schema.MeshPrimitive sMeshPrimitive = meshPrimitive.ConvertToMeshPrimitive(bufferViews, accessors, samplers, images, textures, materials, geometryData, ref buffer, buffer_index, false, false, false, false);
+            Assert.AreEqual(sMeshPrimitive.Indices, 2); // indices is third bufferview, or index 2
+            
+            
+        }
     }
 }

--- a/Source/Runtime/Material.cs
+++ b/Source/Runtime/Material.cs
@@ -13,9 +13,9 @@ namespace AssetGenerator.Runtime
     {
         public struct TextureIndices
         {
-            public int? Sampler_index;
-            public int? Image_index;
-            public int? Texture_coord_index;
+            public int? SamplerIndex;
+            public int? ImageIndex;
+            public int? TextureCoordIndex;
         }
         /// <summary>
         /// The user-defined name of this object
@@ -75,9 +75,9 @@ namespace AssetGenerator.Runtime
         public TextureIndices AddTexture(Runtime.Texture gTexture, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, glTFLoader.Schema.Material material)
         {
             List<int> indices = new List<int>();
-            int? sampler_index = null;
-            int? image_index = null;
-            int? texture_coord_index = null;
+            int? samplerIndex = null;
+            int? imageIndex = null;
+            int? textureCoordIndex = null;
 
             if (gTexture != null)
             {
@@ -86,17 +86,17 @@ namespace AssetGenerator.Runtime
                     // If a similar sampler is already being used in the list, reuse that index instead of creating a new sampler object
                     if (samplers.Count > 0)
                     {
-                        int find_index;
+                        int findIndex;
                         ObjectSearch<glTFLoader.Schema.Sampler> samplerSearch = new ObjectSearch<glTFLoader.Schema.Sampler>(gTexture.Sampler.ConvertToSampler());
-                        find_index = samplers.FindIndex(0, samplers.Count, samplerSearch.Equals);
-                        if (find_index != -1)
-                            sampler_index = find_index;
+                        findIndex = samplers.FindIndex(0, samplers.Count, samplerSearch.Equals);
+                        if (findIndex != -1)
+                            samplerIndex = findIndex;
                     }
-                    if (!sampler_index.HasValue)
+                    if (!samplerIndex.HasValue)
                     {
                         glTFLoader.Schema.Sampler sampler = gTexture.Sampler.ConvertToSampler();
                         samplers.Add(sampler);
-                        sampler_index = samplers.Count() - 1;
+                        samplerIndex = samplers.Count() - 1;
                     }
                 }
                 if (gTexture.Source != null)
@@ -104,42 +104,42 @@ namespace AssetGenerator.Runtime
                     // If an equivalent image object has already been created, reuse its index instead of creating a new image object
                     glTFLoader.Schema.Image image = gTexture.Source.ConvertToImage();
                     ObjectSearch<glTFLoader.Schema.Image> imageSearch = new ObjectSearch<glTFLoader.Schema.Image>(image);
-                    int find_image_index = images.FindIndex(0, images.Count, imageSearch.Equals);
+                    int findImageIndex = images.FindIndex(0, images.Count, imageSearch.Equals);
 
-                    if (find_image_index != -1)
+                    if (findImageIndex != -1)
                     {
-                        image_index = find_image_index;
+                        imageIndex = findImageIndex;
                     }
 
-                    if (!image_index.HasValue)
+                    if (!imageIndex.HasValue)
                     {
                         images.Add(image);
-                        image_index = images.Count() - 1;
+                        imageIndex = images.Count() - 1;
                     }
                 }
                 glTFLoader.Schema.Texture texture = new glTFLoader.Schema.Texture();
-                if (sampler_index.HasValue)
+                if (samplerIndex.HasValue)
                 {
-                    texture.Sampler = sampler_index.Value;
+                    texture.Sampler = samplerIndex.Value;
                 }
-                if (image_index.HasValue)
+                if (imageIndex.HasValue)
                 {
-                    texture.Source = image_index.Value;
+                    texture.Source = imageIndex.Value;
                 }
                 if (gTexture.Name != null)
                 {
                     texture.Name = gTexture.Name;
                 }
                 // If an equivalent texture has already been created, re-use that texture's index instead of creating a new texture
-                int find_texture_index = -1;
+                int findTextureIndex = -1;
                 if (textures.Count > 0)
                 {
                     ObjectSearch<glTFLoader.Schema.Texture> textureSearch = new ObjectSearch<glTFLoader.Schema.Texture>(texture);
-                    find_texture_index = textures.FindIndex(textureSearch.Equals);
+                    findTextureIndex = textures.FindIndex(textureSearch.Equals);
                 }
-                if (find_texture_index > -1)
+                if (findTextureIndex > -1)
                 {
-                    indices.Add(find_texture_index);
+                    indices.Add(findTextureIndex);
                 }
                 else
                 {
@@ -150,15 +150,15 @@ namespace AssetGenerator.Runtime
                 if (gTexture.TexCoordIndex.HasValue)
                 {
                     indices.Add(gTexture.TexCoordIndex.Value);
-                    texture_coord_index = gTexture.TexCoordIndex.Value;
+                    textureCoordIndex = gTexture.TexCoordIndex.Value;
                 }
             }
 
             TextureIndices textureIndices = new TextureIndices
             {
-                Sampler_index = sampler_index,
-                Image_index = image_index,
-                Texture_coord_index = texture_coord_index
+                SamplerIndex = samplerIndex,
+                ImageIndex = imageIndex,
+                TextureCoordIndex = textureCoordIndex
             };
 
             return textureIndices;
@@ -193,13 +193,13 @@ namespace AssetGenerator.Runtime
                     TextureIndices baseColorIndices = AddTexture(MetallicRoughnessMaterial.BaseColorTexture, samplers, images, textures, material);
 
                     material.PbrMetallicRoughness.BaseColorTexture = new glTFLoader.Schema.TextureInfo();
-                    if (baseColorIndices.Image_index.HasValue)
+                    if (baseColorIndices.ImageIndex.HasValue)
                     {
-                        material.PbrMetallicRoughness.BaseColorTexture.Index = baseColorIndices.Image_index.Value;
+                        material.PbrMetallicRoughness.BaseColorTexture.Index = baseColorIndices.ImageIndex.Value;
                     }
-                    if (baseColorIndices.Texture_coord_index.HasValue)
+                    if (baseColorIndices.TextureCoordIndex.HasValue)
                     {
-                        material.PbrMetallicRoughness.BaseColorTexture.TexCoord = baseColorIndices.Texture_coord_index.Value;
+                        material.PbrMetallicRoughness.BaseColorTexture.TexCoord = baseColorIndices.TextureCoordIndex.Value;
                     };
                 }
                 if (MetallicRoughnessMaterial.MetallicRoughnessTexture != null)
@@ -207,13 +207,13 @@ namespace AssetGenerator.Runtime
                    TextureIndices metallicRoughnessIndices = AddTexture(MetallicRoughnessMaterial.MetallicRoughnessTexture, samplers, images, textures, material);
 
                     material.PbrMetallicRoughness.MetallicRoughnessTexture = new glTFLoader.Schema.TextureInfo();
-                    if (metallicRoughnessIndices.Image_index.HasValue)
+                    if (metallicRoughnessIndices.ImageIndex.HasValue)
                     {
-                        material.PbrMetallicRoughness.MetallicRoughnessTexture.Index = metallicRoughnessIndices.Image_index.Value;
+                        material.PbrMetallicRoughness.MetallicRoughnessTexture.Index = metallicRoughnessIndices.ImageIndex.Value;
                     }
-                    if (metallicRoughnessIndices.Texture_coord_index.HasValue)
+                    if (metallicRoughnessIndices.TextureCoordIndex.HasValue)
                     {
-                        material.PbrMetallicRoughness.MetallicRoughnessTexture.TexCoord = metallicRoughnessIndices.Texture_coord_index.Value;
+                        material.PbrMetallicRoughness.MetallicRoughnessTexture.TexCoord = metallicRoughnessIndices.TextureCoordIndex.Value;
                     }
                 }
                 if (MetallicRoughnessMaterial.MetallicFactor.HasValue)
@@ -240,41 +240,41 @@ namespace AssetGenerator.Runtime
                 TextureIndices normalIndicies = AddTexture(NormalTexture, samplers, images, textures, material);
                 material.NormalTexture = new glTFLoader.Schema.MaterialNormalTextureInfo();
 
-                if (normalIndicies.Image_index.HasValue)
+                if (normalIndicies.ImageIndex.HasValue)
                 {
-                    material.NormalTexture.Index = normalIndicies.Image_index.Value;
+                    material.NormalTexture.Index = normalIndicies.ImageIndex.Value;
 
                 }
-                if (normalIndicies.Texture_coord_index.HasValue)
+                if (normalIndicies.TextureCoordIndex.HasValue)
                 {
-                    material.NormalTexture.TexCoord = normalIndicies.Texture_coord_index.Value;
+                    material.NormalTexture.TexCoord = normalIndicies.TextureCoordIndex.Value;
                 }
             }
             if (OcclusionTexture != null)
             {
                 TextureIndices occlusionIndicies = AddTexture(OcclusionTexture, samplers, images, textures, material);
                 material.OcclusionTexture = new glTFLoader.Schema.MaterialOcclusionTextureInfo();
-                if (occlusionIndicies.Image_index.HasValue)
+                if (occlusionIndicies.ImageIndex.HasValue)
                 {
-                    material.OcclusionTexture.Index = occlusionIndicies.Image_index.Value;
+                    material.OcclusionTexture.Index = occlusionIndicies.ImageIndex.Value;
 
                 };
-                if (occlusionIndicies.Texture_coord_index.HasValue)
+                if (occlusionIndicies.TextureCoordIndex.HasValue)
                 {
-                    material.OcclusionTexture.TexCoord = occlusionIndicies.Texture_coord_index.Value;
+                    material.OcclusionTexture.TexCoord = occlusionIndicies.TextureCoordIndex.Value;
                 }
             }
             if (EmissiveTexture != null)
             {
                 TextureIndices emissiveIndicies = AddTexture(EmissiveTexture, samplers, images, textures, material);
                 material.EmissiveTexture = new glTFLoader.Schema.TextureInfo();
-                if (emissiveIndicies.Image_index.HasValue)
+                if (emissiveIndicies.ImageIndex.HasValue)
                 {
-                    material.EmissiveTexture.Index = emissiveIndicies.Image_index.Value;
+                    material.EmissiveTexture.Index = emissiveIndicies.ImageIndex.Value;
                 }
-                if (emissiveIndicies.Texture_coord_index.HasValue)
+                if (emissiveIndicies.TextureCoordIndex.HasValue)
                 {
-                    material.EmissiveTexture.TexCoord = emissiveIndicies.Texture_coord_index.Value;
+                    material.EmissiveTexture.TexCoord = emissiveIndicies.TextureCoordIndex.Value;
                 }
             }
             if (AlphaMode.HasValue)

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -233,7 +233,7 @@ namespace AssetGenerator.Runtime
         /// <summary>
         /// Creates an Accessor object
         /// </summary>
-        /// <param name="bufferview_index"></param>
+        /// <param name="bufferviewIndex"></param>
         /// <param name="byteOffset"></param>
         /// <param name="componentType"></param>
         /// <param name="count"></param>
@@ -243,11 +243,11 @@ namespace AssetGenerator.Runtime
         /// <param name="type"></param>
         /// <param name="normalized"></param>
         /// <returns></returns>
-        private glTFLoader.Schema.Accessor CreateAccessor(int bufferview_index, int? byteOffset, glTFLoader.Schema.Accessor.ComponentTypeEnum? componentType, int? count, string name, float[] max, float[] min, glTFLoader.Schema.Accessor.TypeEnum? type, bool? normalized)
+        private glTFLoader.Schema.Accessor CreateAccessor(int bufferviewIndex, int? byteOffset, glTFLoader.Schema.Accessor.ComponentTypeEnum? componentType, int? count, string name, float[] max, float[] min, glTFLoader.Schema.Accessor.TypeEnum? type, bool? normalized)
         {
             glTFLoader.Schema.Accessor accessor = new glTFLoader.Schema.Accessor
             {
-                BufferView = bufferview_index,
+                BufferView = bufferviewIndex,
                 Name = name,
             };
             if (min != null && min.Count() > 0)
@@ -312,10 +312,10 @@ namespace AssetGenerator.Runtime
                 }
                 glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Positions", byteLength, buffer.ByteLength);
                 bufferViews.Add(bufferView);
-                int bufferview_index = bufferViews.Count() - 1;
+                int bufferviewIndex = bufferViews.Count() - 1;
 
                 // Create an accessor for the bufferView
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Positions.Count(), "Positions Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Positions.Count(), "Positions Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
                 buffer.ByteLength += byteLength;
              
 
@@ -343,10 +343,10 @@ namespace AssetGenerator.Runtime
                     min = new[] { minMaxNormals[1].x, minMaxNormals[1].y, minMaxNormals[1].z };
                 }
                 bufferViews.Add(bufferView);
-                int bufferview_index = bufferViews.Count() - 1;
+                int bufferviewIndex = bufferViews.Count() - 1;
 
                 // Create an accessor for the bufferView
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Normals.Count(), "Normals Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Normals.Count(), "Normals Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
                 
                 buffer.ByteLength += byteLength;
                 accessors.Add(accessor);
@@ -372,10 +372,10 @@ namespace AssetGenerator.Runtime
                 }
 
                 bufferViews.Add(bufferView);
-                int bufferview_index = bufferViews.Count() - 1;
+                int bufferviewIndex = bufferViews.Count() - 1;
                 
                 // Create an accessor for the bufferView
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Tangents.Count(), "Tangents Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, Tangents.Count(), "Tangents Accessor", max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
                 buffer.ByteLength += byteLength;
                 accessors.Add(accessor);
                 geometryData.Writer.Write(Tangents.ToArray());
@@ -528,23 +528,23 @@ namespace AssetGenerator.Runtime
                     }
                     
                     bufferViews.Add(bufferView);
-                    int bufferview_index = bufferViews.Count() - 1;
+                    int bufferviewIndex = bufferViews.Count() - 1;
                     glTFLoader.Schema.Accessor accessor;
                     // we normalize only if the texture cood accessor type is not float
                     bool normalized = TextureCoordsAccessorMode != TextureCoordsAccessorModeEnum.FLOAT;
                     switch(TextureCoordsAccessorMode)
                     {
                         case TextureCoordsAccessorModeEnum.FLOAT:
-                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
                             break;
                         case TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE:
-                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
                             break;
                         case TextureCoordsAccessorModeEnum.NORMALIZED_USHORT:
-                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
                             break;
                         default: // Default to Float
-                            accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
+                            accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, textureCoordSet.Count(), "UV Accessor " + (i + 1), max, min, glTFLoader.Schema.Accessor.TypeEnum.VEC2, normalized);
                             break;
                     }
                     buffer.ByteLength += byteLength;
@@ -610,10 +610,10 @@ namespace AssetGenerator.Runtime
                             glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Positions", byteLength, buffer.ByteLength);
 
                             bufferViews.Add(bufferView);
-                            int bufferview_index = bufferViews.Count() - 1;
+                            int bufferviewIndex = bufferViews.Count() - 1;
 
                             // Create an accessor for the bufferView
-                            glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Positions.Count(), "Positions Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                            glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Positions.Count(), "Positions Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
                             buffer.ByteLength += byteLength;
                             accessors.Add(accessor);
                             geometryData.Writer.Write(morphTarget.Positions.ToArray());
@@ -628,10 +628,10 @@ namespace AssetGenerator.Runtime
                         //get the max and min values
 
                         bufferViews.Add(bufferView);
-                        int bufferview_index = bufferViews.Count() - 1;
+                        int bufferviewIndex = bufferViews.Count() - 1;
 
                         // Create an accessor for the bufferView
-                        glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Normals.Count(), "Normals Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                        glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Normals.Count(), "Normals Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
 
                         buffer.ByteLength += byteLength;
                         accessors.Add(accessor);
@@ -646,10 +646,10 @@ namespace AssetGenerator.Runtime
                         //get the max and min values
 
                         bufferViews.Add(bufferView);
-                        int bufferview_index = bufferViews.Count() - 1;
+                        int bufferviewIndex = bufferViews.Count() - 1;
 
                         // Create an accessor for the bufferView
-                        glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Tangents.Count(), "Tangents Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
+                        glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT, morphTarget.Tangents.Count(), "Tangents Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.VEC3, null);
 
                         buffer.ByteLength += byteLength;
                         accessors.Add(accessor);

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -219,14 +219,14 @@ namespace AssetGenerator.Runtime
         /// <param name="byteLength"></param>
         /// <param name="byteOffset"></param>
         /// <returns>BufferView</returns>
-        private glTFLoader.Schema.BufferView CreateBufferView(int buffer_index, string name, int byteLength, int byteOffset)
+        private glTFLoader.Schema.BufferView CreateBufferView(int bufferIndex, string name, int byteLength, int byteOffset)
         {
             glTFLoader.Schema.BufferView bufferView = new glTFLoader.Schema.BufferView
             {
                 Name = name,
                 ByteLength = byteLength,
                 ByteOffset = byteOffset,
-                Buffer = buffer_index
+                Buffer = bufferIndex
             };
             return bufferView;
         }
@@ -292,7 +292,7 @@ namespace AssetGenerator.Runtime
         /// <param name="geometryData"></param>
         /// <param name="gBuffer"></param>
         /// <returns>MeshPrimitive instance</returns>
-        public glTFLoader.Schema.MeshPrimitive ConvertToMeshPrimitive(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int buffer_index, bool minMaxRangePositions, bool minMaxRangeNormals, bool minMaxRangeTangents, bool minMaxRangeTextureCoords)
+        public glTFLoader.Schema.MeshPrimitive ConvertToMeshPrimitive(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, List<glTFLoader.Schema.Sampler> samplers, List<glTFLoader.Schema.Image> images, List<glTFLoader.Schema.Texture> textures, List<glTFLoader.Schema.Material> materials, Data geometryData, ref glTFLoader.Schema.Buffer buffer, int bufferIndex, bool minMaxRangePositions, bool minMaxRangeNormals, bool minMaxRangeTangents, bool minMaxRangeTextureCoords)
         {
             Dictionary<string, int> attributes = new Dictionary<string, int>();
             glTFLoader.Schema.MeshPrimitive mPrimitive = new glTFLoader.Schema.MeshPrimitive();
@@ -310,7 +310,7 @@ namespace AssetGenerator.Runtime
                     max = new[] { minMaxPositions[0].x, minMaxPositions[0].y, minMaxPositions[0].z };
                     min = new[] { minMaxPositions[1].x, minMaxPositions[1].y, minMaxPositions[1].z };
                 }
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer.ByteLength);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Positions", byteLength, buffer.ByteLength);
                 bufferViews.Add(bufferView);
                 int bufferview_index = bufferViews.Count() - 1;
 
@@ -329,7 +329,7 @@ namespace AssetGenerator.Runtime
                 // Create BufferView
                 int byteLength = sizeof(float) * 3 * Normals.Count();
                 // Create a bufferView
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Normals", byteLength, buffer.ByteLength);
                 
                 //get the max and min values
                 float[] min = new float[] { };
@@ -358,7 +358,7 @@ namespace AssetGenerator.Runtime
                 // Create BufferView
                 int byteLength = sizeof(float) * 3 * Tangents.Count();
                 // Create a bufferView
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Tangents", byteLength, buffer.ByteLength);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Tangents", byteLength, buffer.ByteLength);
 
                 //get the max and min values
                 float[] min = new float[] { };
@@ -384,12 +384,12 @@ namespace AssetGenerator.Runtime
             if (Indices != null && Indices.Count() > 0)
             {
                 int byteLength = sizeof(int) * Indices.Count();
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Indices", byteLength, buffer.ByteLength);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Indices", byteLength, buffer.ByteLength);
 
                 bufferViews.Add(bufferView);
-                int bufferview_index = bufferViews.Count() - 1;
+                int bufferviewIndex = bufferViews.Count() - 1;
 
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_INT, Indices.Count(), "Indices Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.SCALAR, null);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_INT, Indices.Count(), "Indices Accessor", null, null, glTFLoader.Schema.Accessor.TypeEnum.SCALAR, null);
                 buffer.ByteLength += byteLength;
                 accessors.Add(accessor);
                 foreach(var indice in Indices)
@@ -489,15 +489,15 @@ namespace AssetGenerator.Runtime
                         break;
                 }
                 // Create BufferView
-                glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Colors", byteLength, buffer.ByteLength);
+                glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Colors", byteLength, buffer.ByteLength);
                 bufferViews.Add(bufferView);
-                int bufferview_index = bufferViews.Count() - 1;
+                int bufferviewIndex = bufferViews.Count() - 1;
                 buffer.ByteLength += byteLength;
 
                 // Create an accessor for the bufferView
                 // we normalize if the color accessor mode is not set to FLOAT
                 bool normalized = (ColorAccessorMode & ColorAccessorModeEnum.FLOAT) != ColorAccessorModeEnum.FLOAT;
-                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferview_index, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, colorAccessorType, normalized);
+                glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, colorAccessorType, normalized);
                 accessors.Add(accessor);
                 attributes.Add("COLOR_0", accessors.Count() - 1);
             }
@@ -517,7 +517,7 @@ namespace AssetGenerator.Runtime
                     int byteLength = sizeof(float) * 2 * textureCoordSet.Count();
 
                     // Create a bufferView
-                    glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Texture Coords " + (i + 1), byteLength, buffer.ByteLength);
+                    glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Texture Coords " + (i + 1), byteLength, buffer.ByteLength);
                     
                     float[] min = new float[] { };
                     float[] max = new float[] { };
@@ -590,7 +590,7 @@ namespace AssetGenerator.Runtime
         /// <summary>
         /// Converts the morph target list of dictionaries into Morph Target
         /// </summary>
-        public List<Dictionary<string, int>> GetMorphTargets(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, ref glTFLoader.Schema.Buffer buffer, Data geometryData, ref List<float> weights,  int buffer_index)
+        public List<Dictionary<string, int>> GetMorphTargets(List<glTFLoader.Schema.BufferView> bufferViews, List<glTFLoader.Schema.Accessor> accessors, ref glTFLoader.Schema.Buffer buffer, Data geometryData, ref List<float> weights,  int bufferIndex)
         {
             List<Dictionary<string, int>> morphTargetDicts = new List<Dictionary<string, int>>();
             if (MorphTargets != null)
@@ -607,7 +607,7 @@ namespace AssetGenerator.Runtime
                             //Create BufferView for the position
                             int byteLength = sizeof(float) * 3 * morphTarget.Positions.Count();
                             
-                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Positions", byteLength, buffer.ByteLength);
+                            glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Positions", byteLength, buffer.ByteLength);
 
                             bufferViews.Add(bufferView);
                             int bufferview_index = bufferViews.Count() - 1;
@@ -624,7 +624,7 @@ namespace AssetGenerator.Runtime
                     {
                         int byteLength = sizeof(float) * 3 * morphTarget.Normals.Count();
                         // Create a bufferView
-                        glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Normals", byteLength, buffer.ByteLength);
+                        glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Normals", byteLength, buffer.ByteLength);
                         //get the max and min values
 
                         bufferViews.Add(bufferView);
@@ -642,7 +642,7 @@ namespace AssetGenerator.Runtime
                     {
                         int byteLength = sizeof(float) * 3 * morphTarget.Tangents.Count();
                         // Create a bufferView
-                        glTFLoader.Schema.BufferView bufferView = CreateBufferView(buffer_index, "Tangents", byteLength, buffer.ByteLength);
+                        glTFLoader.Schema.BufferView bufferView = CreateBufferView(bufferIndex, "Tangents", byteLength, buffer.ByteLength);
                         //get the max and min values
 
                         bufferViews.Add(bufferView);


### PR DESCRIPTION
Adding `Indices` property to `Runtime.MeshPrimitive`
Added unit test for `Indices` property
switching local variables to camelCase instead of using underscores