### PR TITLE
Ensuring that color accessor enum has a 0 value

### DIFF
--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -15,7 +15,7 @@ namespace AssetGenerator.Runtime
         /// Specifies which mode to use when defining the color accessor (Float is the default value)
         /// </summary>
         [Flags]
-        public enum ColorAccessorModeEnum { FLOAT = 0x001, NORMALIZED_USHORT = 0x002, NORMALIZED_UBYTE = 0x004, VEC3 = 0x100, VEC4 = 0x200 };
+        public enum ColorAccessorModeEnum { NONE = 0, FLOAT = 1, NORMALIZED_USHORT = 2, NORMALIZED_UBYTE = 3, VEC3 = 0x100, VEC4 = 0x200 };
         /// <summary>
         /// Specifies which mode to use when defining the texture coordinates accessor (Float is the default value)
         /// </summary>


### PR DESCRIPTION
This should allow the bit flags to work internally in `Runtime.MeshPrimitive` and follows best practices regarding enum usage in C#: https://msdn.microsoft.com/en-us/library/ms182149.aspx