### PR TITLE
Split color enum into two

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -99,11 +99,10 @@ namespace AssetGenerator.Runtime.Tests
         {
             MeshPrimitive meshPrimitive = new MeshPrimitive();
 
-            meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.FLOAT | MeshPrimitive.ColorAccessorModeEnum.VEC3;
-            Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.FLOAT | MeshPrimitive.ColorAccessorModeEnum.VEC3);
-
-            meshPrimitive.ColorAccessorMode = MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4;
-            Assert.AreEqual(meshPrimitive.ColorAccessorMode, MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE | MeshPrimitive.ColorAccessorModeEnum.VEC4);
+            meshPrimitive.ColorMode = MeshPrimitive.ColorModeEnum.FLOAT;
+            meshPrimitive.ColorType = MeshPrimitive.ColorTypeEnum.VEC3;
+            Assert.AreEqual(meshPrimitive.ColorMode, MeshPrimitive.ColorModeEnum.FLOAT);
+            Assert.AreEqual(meshPrimitive.ColorType, MeshPrimitive.ColorTypeEnum.VEC3);
         }
 
         [TestMethod()]

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -322,44 +322,38 @@ namespace AssetGenerator
                             }
                             else if (param.name == ParameterName.Color_VEC3_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.FLOAT |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC3;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.FLOAT |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC4;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC3_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC3;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_UBYTE |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC4;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC3_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_USHORT |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC3;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorAccessorMode =
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.NORMALIZED_USHORT |
-                                    Runtime.MeshPrimitive.ColorAccessorModeEnum.VEC4;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                         }


### PR DESCRIPTION
Changes the interface for setting the color accessor attributes using `ColorModeEnum` and `ColorTypeEnum`