### PR TITLE
Name change for color component type and texture coords component type

### DIFF
--- a/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
+++ b/Source/AssetGeneratorTests/Runtime/MeshPrimitiveTests.cs
@@ -99,9 +99,9 @@ namespace AssetGenerator.Runtime.Tests
         {
             MeshPrimitive meshPrimitive = new MeshPrimitive();
 
-            meshPrimitive.ColorMode = MeshPrimitive.ColorModeEnum.FLOAT;
+            meshPrimitive.ColorComponentType = MeshPrimitive.ColorComponentTypeEnum.FLOAT;
             meshPrimitive.ColorType = MeshPrimitive.ColorTypeEnum.VEC3;
-            Assert.AreEqual(meshPrimitive.ColorMode, MeshPrimitive.ColorModeEnum.FLOAT);
+            Assert.AreEqual(meshPrimitive.ColorComponentType, MeshPrimitive.ColorComponentTypeEnum.FLOAT);
             Assert.AreEqual(meshPrimitive.ColorType, MeshPrimitive.ColorTypeEnum.VEC3);
         }
 

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -274,26 +274,26 @@ namespace AssetGenerator
                             }
                             else if (param.name == ParameterName.TexCoord0_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets[0] = param.value;
                             }
                             else if (param.name == ParameterName.TexCoord0_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets[0] = param.value;
                             }
                             else if (param.name == ParameterName.TexCoord0_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_USHORT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets[0] = param.value;
                             }
                             else if (param.name == ParameterName.TexCoord1_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets.Add(param.value);
 
                                 var occlusion = makeTest.requiredParameters.Find(e => e.name == ParameterName.OcclusionTexture);
@@ -302,8 +302,8 @@ namespace AssetGenerator
                             }
                             else if (param.name == ParameterName.TexCoord1_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets.Add(param.value);
 
                                 var occlusion = makeTest.requiredParameters.Find(e => e.name == ParameterName.OcclusionTexture);
@@ -312,8 +312,8 @@ namespace AssetGenerator
                             }
                             else if (param.name == ParameterName.TexCoord1_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsAccessorMode =
-                                    Runtime.MeshPrimitive.TextureCoordsAccessorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordsComponentType =
+                                    Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_USHORT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].TextureCoordSets.Add(param.value);
 
                                 var occlusion = makeTest.requiredParameters.Find(e => e.name == ParameterName.OcclusionTexture);
@@ -322,37 +322,37 @@ namespace AssetGenerator
                             }
                             else if (param.name == ParameterName.Color_VEC3_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.FLOAT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_FLOAT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.FLOAT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.FLOAT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC3_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.NORMALIZED_UBYTE;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_BYTE)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_UBYTE;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.NORMALIZED_UBYTE;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC3_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.NORMALIZED_USHORT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC3;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }
                             else if (param.name == ParameterName.Color_VEC4_SHORT)
                             {
-                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorMode = Runtime.MeshPrimitive.ColorModeEnum.NORMALIZED_USHORT;
+                                wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorComponentType = Runtime.MeshPrimitive.ColorComponentTypeEnum.NORMALIZED_USHORT;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].ColorType = Runtime.MeshPrimitive.ColorTypeEnum.VEC4;
                                 wrapper.Scenes[0].Meshes[0].MeshPrimitives[0].Colors = param.value;
                             }

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -84,7 +84,7 @@ namespace AssetGenerator.Runtime
         public float morphTargetWeight { get; set; }
 
         /// <summary>
-        /// Sets the rendering mode of the primitive to render.
+        /// Sets the mode of the primitive to render.
         /// </summary>
         public glTFLoader.Schema.MeshPrimitive.ModeEnum Mode { get; set; }
 

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -7,25 +7,38 @@ using System.Threading.Tasks;
 namespace AssetGenerator.Runtime
 {
     /// <summary>
-    /// Runtime abstraction for Mesh Primitive
+    /// Runtime abstraction for glTF Mesh Primitive
     /// </summary>
     public class MeshPrimitive
     {
         /// <summary>
-        /// Specifies which mode to use when defining the color accessor (Float is the default value)
+        /// Specifies which component type to use when defining the color accessor 
         /// </summary>
-        [Flags]
-        public enum ColorModeEnum { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
-        [Flags]
-        public enum ColorTypeEnum { VEC3, VEC4 };
+        public enum ColorComponentTypeEnum { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
+        
         /// <summary>
-        /// Specifies which mode to use when defining the texture coordinates accessor (Float is the default value)
+        /// Specifies which data type to use when defining the color accessor
         /// </summary>
-        public enum TextureCoordsAccessorModeEnum { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
-
-        public ColorModeEnum ColorMode { get; set; }
+        public enum ColorTypeEnum { VEC3, VEC4 };
+     
+        /// <summary>
+        /// Specifies which color component type to use for the mesh primitive instance
+        /// </summary>
+        public ColorComponentTypeEnum ColorComponentType { get; set; }
+        /// <summary>
+        /// Specifies which color data type to use for the mesh primitive instance
+        /// </summary>
         public ColorTypeEnum ColorType { get; set; }
-        public TextureCoordsAccessorModeEnum TextureCoordsAccessorMode { get; set; }
+        
+        /// <summary>
+        /// Specifies which component type to use when defining the texture coordinates accessor 
+        /// </summary>
+        public enum TextureCoordsComponentTypeEnum { FLOAT, NORMALIZED_USHORT, NORMALIZED_UBYTE };
+
+        /// <summary>
+        /// Specifies which texture coords component type to use for the mesh primitive instance
+        /// </summary>
+        public TextureCoordsComponentTypeEnum TextureCoordsComponentType { get; set; }
 
         /// <summary>
         /// Material for the mesh primitive
@@ -71,7 +84,7 @@ namespace AssetGenerator.Runtime
         public float morphTargetWeight { get; set; }
 
         /// <summary>
-        /// Sets the type of primitive to render.
+        /// Sets the rendering mode of the primitive to render.
         /// </summary>
         public glTFLoader.Schema.MeshPrimitive.ModeEnum Mode { get; set; }
 
@@ -127,6 +140,7 @@ namespace AssetGenerator.Runtime
             };
             return bufferView;
         }
+
         /// <summary>
         /// Creates an Accessor object
         /// </summary>
@@ -278,9 +292,9 @@ namespace AssetGenerator.Runtime
                 int vectorSize = ColorType == ColorTypeEnum.VEC3 ? 3 : 4;
                 int byteLength = sizeof(float) * vectorSize * Colors.Count();
 
-                switch (ColorMode)
+                switch (ColorComponentType)
                 {
-                    case ColorModeEnum.FLOAT:
+                    case ColorComponentTypeEnum.FLOAT:
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
 
                         foreach (Vector4 color in Colors)
@@ -294,7 +308,7 @@ namespace AssetGenerator.Runtime
                             }
                         }
                         break;
-                    case ColorModeEnum.NORMALIZED_UBYTE:
+                    case ColorComponentTypeEnum.NORMALIZED_UBYTE:
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE;
                     
                         foreach (Vector4 color in Colors)
@@ -308,7 +322,7 @@ namespace AssetGenerator.Runtime
                             }
                         }
                         break;
-                    case ColorModeEnum.NORMALIZED_USHORT:
+                    case ColorComponentTypeEnum.NORMALIZED_USHORT:
                         colorAccessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT;
                        
                         foreach (Vector4 color in Colors)
@@ -331,7 +345,7 @@ namespace AssetGenerator.Runtime
 
                 // Create an accessor for the bufferView
                 // we normalize if the color accessor mode is not set to FLOAT
-                bool normalized = ColorMode != ColorModeEnum.FLOAT;
+                bool normalized = ColorComponentType != ColorComponentTypeEnum.FLOAT;
                 glTFLoader.Schema.Accessor accessor = CreateAccessor(bufferviewIndex, 0, colorAccessorComponentType, Colors.Count(), "Colors Accessor", null, null, colorAccessorType, normalized);
                 accessors.Add(accessor);
                 attributes.Add("COLOR_0", accessors.Count() - 1);
@@ -354,18 +368,18 @@ namespace AssetGenerator.Runtime
                     glTFLoader.Schema.Accessor accessor;
                     glTFLoader.Schema.Accessor.ComponentTypeEnum accessorComponentType;
                     // we normalize only if the texture cood accessor type is not float
-                    bool normalized = TextureCoordsAccessorMode != TextureCoordsAccessorModeEnum.FLOAT;
-                    switch(TextureCoordsAccessorMode)
+                    bool normalized = TextureCoordsComponentType != TextureCoordsComponentTypeEnum.FLOAT;
+                    switch(TextureCoordsComponentType)
                     {
-                        case TextureCoordsAccessorModeEnum.FLOAT:
+                        case TextureCoordsComponentTypeEnum.FLOAT:
                             accessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.FLOAT;
                             byteLength = sizeof(float) * 2 * textureCoordSet.Count();
                             break;
-                        case TextureCoordsAccessorModeEnum.NORMALIZED_UBYTE:
+                        case TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE:
                             accessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_BYTE;
                             byteLength = sizeof(byte) * 2 * textureCoordSet.Count();
                             break;
-                        case TextureCoordsAccessorModeEnum.NORMALIZED_USHORT:
+                        case TextureCoordsComponentTypeEnum.NORMALIZED_USHORT:
                             accessorComponentType = glTFLoader.Schema.Accessor.ComponentTypeEnum.UNSIGNED_SHORT;
                             byteLength = sizeof(ushort) * 2 * textureCoordSet.Count();
                             break;


### PR DESCRIPTION
One more name change for the color component type and texture coords component type enums.  

`ColorMode` is now `ColorComponentType`
`TextureCoordsMode` is now `TextureCoordsComponentType`

This should be more consistent with the glTF schema.