### PR TITLE
removed wrapper from model function names

### DIFF
--- a/Source/Common.cs
+++ b/Source/Common.cs
@@ -11,7 +11,7 @@ namespace AssetGenerator
         /// <param name="gltf"></param>
         /// <param name="geometryData"></param>
         /// <returns>GLTFWrapper object</returns>
-        public static Runtime.GLTF SingleTriangleMultipleUVSetsWrapper(Gltf gltf, Data geometryData)
+        public static Runtime.GLTF SingleTriangle(Gltf gltf, Data geometryData)
         {
             List<Vector3> trianglePositions = new List<Vector3>()
             {
@@ -57,7 +57,7 @@ namespace AssetGenerator
             return wrapper;
 
         }
-        public static Runtime.GLTF SinglePlaneWrapper(Gltf gltf, Data geometryData)
+        public static Runtime.GLTF SinglePlane(Gltf gltf, Data geometryData)
         {
             List<Vector3> planePositions = new List<Vector3>()
             {
@@ -106,7 +106,7 @@ namespace AssetGenerator
             return wrapper;
         }
 
-        public static Runtime.GLTF SingleCubeWrapper(Gltf gltf, Data geometryData)
+        public static Runtime.GLTF SingleCube(Gltf gltf, Data geometryData)
         {
             List<Vector3> cubePositions = new List<Vector3>()
             {

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -157,7 +157,7 @@ namespace AssetGenerator
 
                     var geometryData = new Data(test.ToString() + "_" + comboIndex + ".bin");
                     dataList.Add(geometryData);
-                    Runtime.GLTF wrapper = Common.SinglePlaneWrapper(gltf, geometryData);
+                    Runtime.GLTF wrapper = Common.SinglePlane(gltf, geometryData);
                     Runtime.Material mat = new Runtime.Material();
 
                     if (makeTest.testArea == Tests.Material)


### PR DESCRIPTION
Removing the word "wrapper" from model function names since we are only using the runtime abstraction.
Also shortening the name `SingleTriangleMultipleUVSetsWrapper` to `SingleTriangle`.