### PR TITLE
use four vertices instead of 6 for overrides

### DIFF
--- a/Source/Tests/Primitive_Attribute.cs
+++ b/Source/Tests/Primitive_Attribute.cs
@@ -25,15 +25,11 @@ namespace AssetGenerator.Tests
                 new Vector3( 0.0f, 0.0f,-1.0f),
                 new Vector3( 0.0f, 0.0f,-1.0f),
                 new Vector3( 0.0f, 0.0f,-1.0f),
-                new Vector3( 0.0f, 0.0f,-1.0f),
-                new Vector3( 0.0f, 0.0f,-1.0f),
                 new Vector3( 0.0f, 0.0f,-1.0f)
             };
             List<Vector2> uvCoord2 = new List<Vector2>()
             {
                 new Vector2(0.0f, 1.0f),
-                new Vector2(1.0f, 1.0f),
-                new Vector2(0.0f, 0.0f),
                 new Vector2(1.0f, 1.0f),
                 new Vector2(1.0f, 0.0f),
                 new Vector2(0.0f, 0.0f)
@@ -42,15 +38,11 @@ namespace AssetGenerator.Tests
             {
                 new Vector4( 1.0f, 0.0f, 0.0f, 0.8f),
                 new Vector4( 0.0f, 0.0f, 1.0f, 0.8f),
-                new Vector4( 0.0f, 0.0f, 1.0f, 0.8f),
-                new Vector4( 0.0f, 0.0f, 1.0f, 0.8f),
                 new Vector4( 1.0f, 0.0f, 0.0f, 0.8f),
                 new Vector4( 0.0f, 0.0f, 1.0f, 0.8f)
             };
             List<Vector4> tanCoord = new List<Vector4>()
             {
-                new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
-                new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
                 new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
                 new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
                 new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),

--- a/Source/Tests/Texture_Sampler.cs
+++ b/Source/Tests/Texture_Sampler.cs
@@ -21,8 +21,6 @@ namespace AssetGenerator.Tests
             {
                 new Vector2(-0.3f, 1.3f),
                 new Vector2( 1.3f, 1.3f),
-                new Vector2(-0.3f,-0.3f),
-                new Vector2( 1.3f, 1.3f),
                 new Vector2( 1.3f,-0.3f),
                 new Vector2(-0.3f,-0.3f)
             };


### PR DESCRIPTION
This adds in the update for the color bug fix and switches the primitive attribute tests to use four values instead of 6 for the plane