### PR TITLE
Update for Material_Alpha test set

### DIFF
--- a/Source/Tests/Material_Alpha.cs
+++ b/Source/Tests/Material_Alpha.cs
@@ -15,7 +15,7 @@ namespace AssetGenerator.Tests
                 Uri = texture_BaseColor
             };
             usedImages.Add(baseColorTexture);
-            List<Vector4> colorCoord = new List<Vector4>()
+            List<Vector4> vertexColors = new List<Vector4>()
             {
                 new Vector4( 0.3f, 0.3f, 0.3f, 0.4f),
                 new Vector4( 0.3f, 0.3f, 0.3f, 0.2f),
@@ -24,7 +24,7 @@ namespace AssetGenerator.Tests
             };
             properties = new List<Property>
             {
-                new Property(Propertyname.VertexColor_Vector4_Float, colorCoord, group:2),
+                new Property(Propertyname.VertexColor_Vector4_Float, vertexColors, group:2),
                 new Property(Propertyname.AlphaMode_Mask, glTFLoader.Schema.Material.AlphaModeEnum.MASK, group:1),
                 new Property(Propertyname.AlphaMode_Blend, glTFLoader.Schema.Material.AlphaModeEnum.BLEND, group:1),
                 new Property(Propertyname.AlphaCutoff, 0.7f),
@@ -35,7 +35,7 @@ namespace AssetGenerator.Tests
             specialProperties = new List<Property>
             {
                 new Property(Propertyname.BaseColorTexture, baseColorTexture),
-                new Property(Propertyname.VertexColor_Vector4_Float, colorCoord, group:2),
+                new Property(Propertyname.VertexColor_Vector4_Float, vertexColors, group:2),
             };
             specialCombos.Add(ComboHelper.CustomComboCreation(
                 properties.Find(e => e.name == Propertyname.AlphaMode_Mask),
@@ -84,10 +84,21 @@ namespace AssetGenerator.Tests
                 }
             }
 
-            // Add a AlphaMode_Blend and VertexColor combo to the bottom, so BaseColorTexture isn't split up
+            // Add AlphaMode_Blend/Alphamode_Mask + VertexColor combos to the bottom, so BaseColorTexture isn't split up
             combos.Add(ComboHelper.CustomComboCreation(
                 properties.Find(e => e.name == Propertyname.AlphaMode_Blend),
                 properties.Find(e => e.name == Propertyname.VertexColor_Vector4_Float)));
+            combos.Add(ComboHelper.CustomComboCreation(
+                properties.Find(e => e.name == Propertyname.AlphaMode_Mask),
+                properties.Find(e => e.name == Propertyname.VertexColor_Vector4_Float)));
+
+            // Add two combos to the bottom, so they don't have a base color texture
+            combos.Add(ComboHelper.CustomComboCreation(
+                properties.Find(e => e.name == Propertyname.AlphaMode_Blend),
+                properties.Find(e => e.name == Propertyname.BaseColorFactor)));
+            combos.Add(ComboHelper.CustomComboCreation(
+                properties.Find(e => e.name == Propertyname.AlphaMode_Mask),
+                properties.Find(e => e.name == Propertyname.BaseColorFactor)));
 
             return combos;
         }

--- a/Source/Tests/Primitive_Attribute.cs
+++ b/Source/Tests/Primitive_Attribute.cs
@@ -37,14 +37,14 @@ namespace AssetGenerator.Tests
                 new Vector3( 0.0f, 0.0f,1.0f),
                 new Vector3( 0.0f, 0.0f,1.0f)
             };
-            List<Vector2> uvCoord2 = new List<Vector2>()
+            List<Vector2> textureCoords2 = new List<Vector2>()
             {
                 new Vector2(1.0f, 0.5f),
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.0f),
                 new Vector2(1.0f, 0.0f)
             };
-            List<Vector4> colorCoord = new List<Vector4>()
+            List<Vector4> vertexColors = new List<Vector4>()
             {
                 new Vector4( 0.0f, 1.0f, 0.0f, 0.2f),
                 new Vector4( 1.0f, 0.0f, 0.0f, 0.2f),
@@ -52,7 +52,7 @@ namespace AssetGenerator.Tests
                 new Vector4( 0.0f, 0.0f, 1.0f, 0.2f)
                 
             };
-            List<Vector4> tanCoord = new List<Vector4>()
+            List<Vector4> tangents = new List<Vector4>()
             {
                 new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
                 new Vector4( -1.0f, 0.0f, 0.0f, 1.0f),
@@ -62,7 +62,7 @@ namespace AssetGenerator.Tests
             properties = new List<Property>
             {
                 new Property(Propertyname.VertexNormal, planeNormals),
-                new Property(Propertyname.VertexTangent, tanCoord),
+                new Property(Propertyname.VertexTangent, tangents),
                 new Property(Propertyname.VertexUV0_Float, 
                     Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT, group:1),
                 new Property(Propertyname.VertexUV0_Byte, 
@@ -75,18 +75,18 @@ namespace AssetGenerator.Tests
                     Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE, Propertyname.VertexUV0_Byte, 2),
                 new Property(Propertyname.VertexUV1_Short, 
                     Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_USHORT, Propertyname.VertexUV0_Short, 2),
-                new Property(Propertyname.VertexColor_Vector4_Float, colorCoord, group:3),
-                new Property(Propertyname.VertexColor_Vector4_Byte, colorCoord, group:3),
-                new Property(Propertyname.VertexColor_Vector4_Short, colorCoord, group:3),
-                new Property(Propertyname.VertexColor_Vector3_Float, colorCoord, group:3),
-                new Property(Propertyname.VertexColor_Vector3_Byte, colorCoord, group:3),
-                new Property(Propertyname.VertexColor_Vector3_Short, colorCoord, group:3),
+                new Property(Propertyname.VertexColor_Vector4_Float, vertexColors, group:3),
+                new Property(Propertyname.VertexColor_Vector4_Byte, vertexColors, group:3),
+                new Property(Propertyname.VertexColor_Vector4_Short, vertexColors, group:3),
+                new Property(Propertyname.VertexColor_Vector3_Float, vertexColors, group:3),
+                new Property(Propertyname.VertexColor_Vector3_Byte, vertexColors, group:3),
+                new Property(Propertyname.VertexColor_Vector3_Short, vertexColors, group:3),
                 new Property(Propertyname.NormalTexture, normalTexture),
                 new Property(Propertyname.BaseColorTexture, baseColorTexture),
             };
             specialProperties = new List<Property>
             {
-                new Property(Propertyname.TexCoord, uvCoord2),
+                new Property(Propertyname.TexCoord, textureCoords2),
                 new Property(Propertyname.BaseColorTexture, baseColorTexture),
                 new Property(Propertyname.VertexUV0_Float,
                     Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT, group:1)

--- a/Source/Tests/Texture_Sampler.cs
+++ b/Source/Tests/Texture_Sampler.cs
@@ -17,7 +17,7 @@ namespace AssetGenerator.Tests
                 Uri = texture_BaseColor
             };
             usedImages.Add(baseColorTexture);
-            List<Vector2> uvCoord = new List<Vector2>()
+            List<Vector2> textureCoords2 = new List<Vector2>()
             {
                 new Vector2( 1.3f, 1.3f),
                 new Vector2(-0.3f, 1.3f),
@@ -45,7 +45,7 @@ namespace AssetGenerator.Tests
             };
             specialProperties = new List<Property>
             {
-                new Property(Propertyname.TexCoord, uvCoord)
+                new Property(Propertyname.TexCoord, textureCoords2)
             };
         }
 


### PR DESCRIPTION
Adding three new models to the Material_Alpha test set. They're all at the bottom of the MD table, so the older model's numbers are not affected by this change! This fixes issue #242 

I've also changed `colorCoord `to `vertexColors`. This fixes issue #241 

https://gist.github.com/stevk/692942f9757401eea3e9db784ff3ea5e

![image](https://user-images.githubusercontent.com/31048895/32470035-78c7c0fc-c30a-11e7-9afb-9a05af26079d.png)


