### PR TITLE
Remove unused isRequired list from ComboHelper

### DIFF
--- a/Source/ComboHelper.cs
+++ b/Source/ComboHelper.cs
@@ -10,11 +10,9 @@ namespace AssetGenerator
             List<List<Property>> finalResult;
             List<List<Property>> removeTheseCombos = new List<List<Property>>();
             List<List<Property>> keepTheseCombos = new List<List<Property>>();
-            List<Property> isRequired = new List<Property>();
             List<Property> isPrerequisite = new List<Property>();
             bool hasPrerequisiteAttribute;
 
-            //var combos = PowerSet<Attribute>(attributes);
             var combos = BasicSet<Property>(test.properties);
 
             // Include any special combos


### PR DESCRIPTION
Required properties should be added in each model group's SetModelAttributes function. This allows more flexibility in what is being displayed in the readme, and cuts down on processing time due to longer combo lists.

This fixes issue #273