### PR TITLE
Use a red X for a negative icon in the Material_Mixed readme

### DIFF
--- a/Output/Material_Mixed/README.md
+++ b/Output/Material_Mixed/README.md
@@ -20,6 +20,6 @@ The following table shows the properties that are set for a given model.
 Index | Specular Glossiness On Material 0 | Specular Glossiness On Material 1
 :---: | :---: | :---:
 [00](Material_Mixed_00.gltf) | :white_check_mark: | :white_check_mark:
-[01](Material_Mixed_01.gltf) | :negative_squared_cross_mark: | :negative_squared_cross_mark:
-[02](Material_Mixed_02.gltf) | :white_check_mark: | :negative_squared_cross_mark:
+[01](Material_Mixed_01.gltf) | :x: | :x:
+[02](Material_Mixed_02.gltf) | :white_check_mark: | :x:
  

--- a/Source/ModelGroups/Material_Mixed.cs
+++ b/Source/ModelGroups/Material_Mixed.cs
@@ -73,9 +73,9 @@ namespace AssetGenerator.ModelGroups
             properties = new List<Property>
             {
                 new Property(Propertyname.SpecularGlossinessOnMaterial0_Yes, null, group:2),
-                new Property(Propertyname.SpecularGlossinessOnMaterial0_No, ":negative_squared_cross_mark:", group:2),
+                new Property(Propertyname.SpecularGlossinessOnMaterial0_No, ":x:", group:2),
                 new Property(Propertyname.SpecularGlossinessOnMaterial1_Yes, null, group:3),
-                new Property(Propertyname.SpecularGlossinessOnMaterial1_No, ":negative_squared_cross_mark:", group:3),
+                new Property(Propertyname.SpecularGlossinessOnMaterial1_No, ":x:", group:3),
             };
             specialProperties = new List<Property>
             {


### PR DESCRIPTION
Use :x: instead of :negative_squared_cross_mark: in the Material_Mixed readme.

[Material_Mixed readme](https://github.com/stevk/glTF-Asset-Generator/blob/greenx/Output/Material_Mixed/README.md)

Fix for #337 