### PR TITLE
Make a manifest in each model group output folder

### DIFF
--- a/Output/Buffer_Interleaved/Manifest.json
+++ b/Output/Buffer_Interleaved/Manifest.json
@@ -1,0 +1,10 @@
+{
+  "folder": "Buffer_Interleaved",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf"
+  ]
+}

--- a/Output/Compatibility/Manifest.json
+++ b/Output/Compatibility/Manifest.json
@@ -1,0 +1,11 @@
+{
+  "folder": "Compatibility",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf"
+  ]
+}

--- a/Output/Material/Manifest.json
+++ b/Output/Material/Manifest.json
@@ -1,0 +1,13 @@
+{
+  "folder": "Material",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf"
+  ]
+}

--- a/Output/Material_AlphaBlend/Manifest.json
+++ b/Output/Material_AlphaBlend/Manifest.json
@@ -1,0 +1,13 @@
+{
+  "folder": "Material_AlphaBlend",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf"
+  ]
+}

--- a/Output/Material_AlphaMask/Manifest.json
+++ b/Output/Material_AlphaMask/Manifest.json
@@ -1,0 +1,13 @@
+{
+  "folder": "Material_AlphaMask",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf"
+  ]
+}

--- a/Output/Material_Doublesided/Manifest.json
+++ b/Output/Material_Doublesided/Manifest.json
@@ -1,0 +1,9 @@
+{
+  "folder": "Material_Doublesided",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf"
+  ]
+}

--- a/Output/Material_MetallicRoughness/Manifest.json
+++ b/Output/Material_MetallicRoughness/Manifest.json
@@ -1,0 +1,16 @@
+{
+  "folder": "Material_MetallicRoughness",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf",
+    "09.gltf",
+    "10.gltf"
+  ]
+}

--- a/Output/Material_Mixed/Manifest.json
+++ b/Output/Material_Mixed/Manifest.json
@@ -1,0 +1,8 @@
+{
+  "folder": "Material_Mixed",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf"
+  ]
+}

--- a/Output/Material_SpecularGlossiness/Manifest.json
+++ b/Output/Material_SpecularGlossiness/Manifest.json
@@ -1,0 +1,18 @@
+{
+  "folder": "Material_SpecularGlossiness",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf",
+    "09.gltf",
+    "10.gltf",
+    "11.gltf",
+    "12.gltf"
+  ]
+}

--- a/Output/Mesh_Indices/Manifest.json
+++ b/Output/Mesh_Indices/Manifest.json
@@ -1,0 +1,21 @@
+{
+  "folder": "Mesh_Indices",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf",
+    "09.gltf",
+    "10.gltf",
+    "11.gltf",
+    "12.gltf",
+    "13.gltf",
+    "14.gltf",
+    "15.gltf"
+  ]
+}

--- a/Output/Mesh_Primitives/Manifest.json
+++ b/Output/Mesh_Primitives/Manifest.json
@@ -1,0 +1,11 @@
+{
+  "folder": "Mesh_Primitives",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf"
+  ]
+}

--- a/Output/Mesh_PrimitivesUV/Manifest.json
+++ b/Output/Mesh_PrimitivesUV/Manifest.json
@@ -1,0 +1,14 @@
+{
+  "folder": "Mesh_PrimitivesUV",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf"
+  ]
+}

--- a/Output/Node_Attribute/Manifest.json
+++ b/Output/Node_Attribute/Manifest.json
@@ -1,0 +1,14 @@
+{
+  "folder": "Node_Attribute",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf"
+  ]
+}

--- a/Output/Node_NegativeScale/Manifest.json
+++ b/Output/Node_NegativeScale/Manifest.json
@@ -1,0 +1,14 @@
+{
+  "folder": "Node_NegativeScale",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf"
+  ]
+}

--- a/Output/Primitive_Attribute/Manifest.json
+++ b/Output/Primitive_Attribute/Manifest.json
@@ -1,0 +1,13 @@
+{
+  "folder": "Primitive_Attribute",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf"
+  ]
+}

--- a/Output/Primitive_VertexColor/Manifest.json
+++ b/Output/Primitive_VertexColor/Manifest.json
@@ -1,0 +1,11 @@
+{
+  "folder": "Primitive_VertexColor",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf"
+  ]
+}

--- a/Output/Texture_Sampler/Manifest.json
+++ b/Output/Texture_Sampler/Manifest.json
@@ -1,0 +1,19 @@
+{
+  "folder": "Texture_Sampler",
+  "files": [
+    "00.gltf",
+    "01.gltf",
+    "02.gltf",
+    "03.gltf",
+    "04.gltf",
+    "05.gltf",
+    "06.gltf",
+    "07.gltf",
+    "08.gltf",
+    "09.gltf",
+    "10.gltf",
+    "11.gltf",
+    "12.gltf",
+    "13.gltf"
+  ]
+}

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -15,7 +15,7 @@ namespace AssetGenerator
             var executingAssembly = Assembly.GetExecutingAssembly();
             var executingAssemblyFolder = Path.GetDirectoryName(executingAssembly.Location);
             var outputFolder = Path.GetFullPath(Path.Combine(executingAssemblyFolder, @"..\..\..\..\Output"));
-            List<Manifest> manifests = new List<Manifest>();
+            List<Manifest> manifestMaster = new List<Manifest>();
 
             // Make an inventory of what images there are
             var textures = FileHelper.FindImageFiles(executingAssembly, "Textures");
@@ -114,12 +114,16 @@ namespace AssetGenerator
                 }
 
                 readme.WriteOut(executingAssembly, modelGroup, assetFolder);
-                manifests.Add(manifest);
+                manifestMaster.Add(manifest);
+
+                // Write out the manifest JSON specific to this model group
+                string json = Newtonsoft.Json.JsonConvert.SerializeObject(manifest, Newtonsoft.Json.Formatting.Indented);
+                File.WriteAllText(Path.Combine(assetFolder, "Manifest.json"), json);
             }
 
-            // Write out the JSON manifest file
-            string json = Newtonsoft.Json.JsonConvert.SerializeObject(manifests.ToArray(), Newtonsoft.Json.Formatting.Indented);
-            File.WriteAllText(Path.Combine(outputFolder, "Manifest.json"), json);
+            // Write out the master manifest JSON containing all of the model groups
+            string jsonMaster = Newtonsoft.Json.JsonConvert.SerializeObject(manifestMaster.ToArray(), Newtonsoft.Json.Formatting.Indented);
+            File.WriteAllText(Path.Combine(outputFolder, "Manifest.json"), jsonMaster);
 
             Console.WriteLine("Model Creation Complete!");
             Console.WriteLine("Completed in : " + TimeSpan.FromTicks(Stopwatch.GetTimestamp()).ToString());


### PR DESCRIPTION
Adds code for making a manifest file individual to each model group inside of that model group's output folder. Duplicates functionality of the main manifest, but allows for some additional flexibility with automation.

Fix for #336 