### PR TITLE
Fix partial file names in manifest

### DIFF
--- a/Output/Buffer_Interleaved/Manifest.json
+++ b/Output/Buffer_Interleaved/Manifest.json
@@ -1,10 +1,10 @@
 {
   "folder": "Buffer_Interleaved",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf"
+    "Buffer_Interleaved_00.gltf",
+    "Buffer_Interleaved_01.gltf",
+    "Buffer_Interleaved_02.gltf",
+    "Buffer_Interleaved_03.gltf",
+    "Buffer_Interleaved_04.gltf"
   ]
 }

--- a/Output/Compatibility/Manifest.json
+++ b/Output/Compatibility/Manifest.json
@@ -1,11 +1,11 @@
 {
   "folder": "Compatibility",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf"
+    "Compatibility_00.gltf",
+    "Compatibility_01.gltf",
+    "Compatibility_02.gltf",
+    "Compatibility_03.gltf",
+    "Compatibility_04.gltf",
+    "Compatibility_05.gltf"
   ]
 }

--- a/Output/Manifest.json
+++ b/Output/Manifest.json
@@ -2,229 +2,229 @@
   {
     "folder": "Buffer_Interleaved",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf"
+      "Buffer_Interleaved_00.gltf",
+      "Buffer_Interleaved_01.gltf",
+      "Buffer_Interleaved_02.gltf",
+      "Buffer_Interleaved_03.gltf",
+      "Buffer_Interleaved_04.gltf"
     ]
   },
   {
     "folder": "Compatibility",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf"
+      "Compatibility_00.gltf",
+      "Compatibility_01.gltf",
+      "Compatibility_02.gltf",
+      "Compatibility_03.gltf",
+      "Compatibility_04.gltf",
+      "Compatibility_05.gltf"
     ]
   },
   {
     "folder": "Material",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf"
+      "Material_00.gltf",
+      "Material_01.gltf",
+      "Material_02.gltf",
+      "Material_03.gltf",
+      "Material_04.gltf",
+      "Material_05.gltf",
+      "Material_06.gltf",
+      "Material_07.gltf"
     ]
   },
   {
     "folder": "Material_AlphaBlend",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf"
+      "Material_AlphaBlend_00.gltf",
+      "Material_AlphaBlend_01.gltf",
+      "Material_AlphaBlend_02.gltf",
+      "Material_AlphaBlend_03.gltf",
+      "Material_AlphaBlend_04.gltf",
+      "Material_AlphaBlend_05.gltf",
+      "Material_AlphaBlend_06.gltf",
+      "Material_AlphaBlend_07.gltf"
     ]
   },
   {
     "folder": "Material_AlphaMask",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf"
+      "Material_AlphaMask_00.gltf",
+      "Material_AlphaMask_01.gltf",
+      "Material_AlphaMask_02.gltf",
+      "Material_AlphaMask_03.gltf",
+      "Material_AlphaMask_04.gltf",
+      "Material_AlphaMask_05.gltf",
+      "Material_AlphaMask_06.gltf",
+      "Material_AlphaMask_07.gltf"
     ]
   },
   {
     "folder": "Material_Doublesided",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf"
+      "Material_Doublesided_00.gltf",
+      "Material_Doublesided_01.gltf",
+      "Material_Doublesided_02.gltf",
+      "Material_Doublesided_03.gltf"
     ]
   },
   {
     "folder": "Material_MetallicRoughness",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf",
-      "09.gltf",
-      "10.gltf"
+      "Material_MetallicRoughness_00.gltf",
+      "Material_MetallicRoughness_01.gltf",
+      "Material_MetallicRoughness_02.gltf",
+      "Material_MetallicRoughness_03.gltf",
+      "Material_MetallicRoughness_04.gltf",
+      "Material_MetallicRoughness_05.gltf",
+      "Material_MetallicRoughness_06.gltf",
+      "Material_MetallicRoughness_07.gltf",
+      "Material_MetallicRoughness_08.gltf",
+      "Material_MetallicRoughness_09.gltf",
+      "Material_MetallicRoughness_10.gltf"
     ]
   },
   {
     "folder": "Material_Mixed",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf"
+      "Material_Mixed_00.gltf",
+      "Material_Mixed_01.gltf",
+      "Material_Mixed_02.gltf"
     ]
   },
   {
     "folder": "Material_SpecularGlossiness",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf",
-      "09.gltf",
-      "10.gltf",
-      "11.gltf",
-      "12.gltf"
+      "Material_SpecularGlossiness_00.gltf",
+      "Material_SpecularGlossiness_01.gltf",
+      "Material_SpecularGlossiness_02.gltf",
+      "Material_SpecularGlossiness_03.gltf",
+      "Material_SpecularGlossiness_04.gltf",
+      "Material_SpecularGlossiness_05.gltf",
+      "Material_SpecularGlossiness_06.gltf",
+      "Material_SpecularGlossiness_07.gltf",
+      "Material_SpecularGlossiness_08.gltf",
+      "Material_SpecularGlossiness_09.gltf",
+      "Material_SpecularGlossiness_10.gltf",
+      "Material_SpecularGlossiness_11.gltf",
+      "Material_SpecularGlossiness_12.gltf"
     ]
   },
   {
     "folder": "Mesh_Indices",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf",
-      "09.gltf",
-      "10.gltf",
-      "11.gltf",
-      "12.gltf",
-      "13.gltf",
-      "14.gltf",
-      "15.gltf"
+      "Mesh_Indices_00.gltf",
+      "Mesh_Indices_01.gltf",
+      "Mesh_Indices_02.gltf",
+      "Mesh_Indices_03.gltf",
+      "Mesh_Indices_04.gltf",
+      "Mesh_Indices_05.gltf",
+      "Mesh_Indices_06.gltf",
+      "Mesh_Indices_07.gltf",
+      "Mesh_Indices_08.gltf",
+      "Mesh_Indices_09.gltf",
+      "Mesh_Indices_10.gltf",
+      "Mesh_Indices_11.gltf",
+      "Mesh_Indices_12.gltf",
+      "Mesh_Indices_13.gltf",
+      "Mesh_Indices_14.gltf",
+      "Mesh_Indices_15.gltf"
     ]
   },
   {
     "folder": "Mesh_Primitives",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf"
+      "Mesh_Primitives_00.gltf",
+      "Mesh_Primitives_01.gltf",
+      "Mesh_Primitives_02.gltf",
+      "Mesh_Primitives_03.gltf",
+      "Mesh_Primitives_04.gltf",
+      "Mesh_Primitives_05.gltf"
     ]
   },
   {
     "folder": "Mesh_PrimitivesUV",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf"
+      "Mesh_PrimitivesUV_00.gltf",
+      "Mesh_PrimitivesUV_01.gltf",
+      "Mesh_PrimitivesUV_02.gltf",
+      "Mesh_PrimitivesUV_03.gltf",
+      "Mesh_PrimitivesUV_04.gltf",
+      "Mesh_PrimitivesUV_05.gltf",
+      "Mesh_PrimitivesUV_06.gltf",
+      "Mesh_PrimitivesUV_07.gltf",
+      "Mesh_PrimitivesUV_08.gltf"
     ]
   },
   {
     "folder": "Node_Attribute",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf"
+      "Node_Attribute_00.gltf",
+      "Node_Attribute_01.gltf",
+      "Node_Attribute_02.gltf",
+      "Node_Attribute_03.gltf",
+      "Node_Attribute_04.gltf",
+      "Node_Attribute_05.gltf",
+      "Node_Attribute_06.gltf",
+      "Node_Attribute_07.gltf",
+      "Node_Attribute_08.gltf"
     ]
   },
   {
     "folder": "Node_NegativeScale",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf"
+      "Node_NegativeScale_00.gltf",
+      "Node_NegativeScale_01.gltf",
+      "Node_NegativeScale_02.gltf",
+      "Node_NegativeScale_03.gltf",
+      "Node_NegativeScale_04.gltf",
+      "Node_NegativeScale_05.gltf",
+      "Node_NegativeScale_06.gltf",
+      "Node_NegativeScale_07.gltf",
+      "Node_NegativeScale_08.gltf"
     ]
   },
   {
     "folder": "Primitive_Attribute",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf"
+      "Primitive_Attribute_00.gltf",
+      "Primitive_Attribute_01.gltf",
+      "Primitive_Attribute_02.gltf",
+      "Primitive_Attribute_03.gltf",
+      "Primitive_Attribute_04.gltf",
+      "Primitive_Attribute_05.gltf",
+      "Primitive_Attribute_06.gltf",
+      "Primitive_Attribute_07.gltf"
     ]
   },
   {
     "folder": "Primitive_VertexColor",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf"
+      "Primitive_VertexColor_00.gltf",
+      "Primitive_VertexColor_01.gltf",
+      "Primitive_VertexColor_02.gltf",
+      "Primitive_VertexColor_03.gltf",
+      "Primitive_VertexColor_04.gltf",
+      "Primitive_VertexColor_05.gltf"
     ]
   },
   {
     "folder": "Texture_Sampler",
     "files": [
-      "00.gltf",
-      "01.gltf",
-      "02.gltf",
-      "03.gltf",
-      "04.gltf",
-      "05.gltf",
-      "06.gltf",
-      "07.gltf",
-      "08.gltf",
-      "09.gltf",
-      "10.gltf",
-      "11.gltf",
-      "12.gltf",
-      "13.gltf"
+      "Texture_Sampler_00.gltf",
+      "Texture_Sampler_01.gltf",
+      "Texture_Sampler_02.gltf",
+      "Texture_Sampler_03.gltf",
+      "Texture_Sampler_04.gltf",
+      "Texture_Sampler_05.gltf",
+      "Texture_Sampler_06.gltf",
+      "Texture_Sampler_07.gltf",
+      "Texture_Sampler_08.gltf",
+      "Texture_Sampler_09.gltf",
+      "Texture_Sampler_10.gltf",
+      "Texture_Sampler_11.gltf",
+      "Texture_Sampler_12.gltf",
+      "Texture_Sampler_13.gltf"
     ]
   }
 ]

--- a/Output/Material/Manifest.json
+++ b/Output/Material/Manifest.json
@@ -1,13 +1,13 @@
 {
   "folder": "Material",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf"
+    "Material_00.gltf",
+    "Material_01.gltf",
+    "Material_02.gltf",
+    "Material_03.gltf",
+    "Material_04.gltf",
+    "Material_05.gltf",
+    "Material_06.gltf",
+    "Material_07.gltf"
   ]
 }

--- a/Output/Material_AlphaBlend/Manifest.json
+++ b/Output/Material_AlphaBlend/Manifest.json
@@ -1,13 +1,13 @@
 {
   "folder": "Material_AlphaBlend",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf"
+    "Material_AlphaBlend_00.gltf",
+    "Material_AlphaBlend_01.gltf",
+    "Material_AlphaBlend_02.gltf",
+    "Material_AlphaBlend_03.gltf",
+    "Material_AlphaBlend_04.gltf",
+    "Material_AlphaBlend_05.gltf",
+    "Material_AlphaBlend_06.gltf",
+    "Material_AlphaBlend_07.gltf"
   ]
 }

--- a/Output/Material_AlphaMask/Manifest.json
+++ b/Output/Material_AlphaMask/Manifest.json
@@ -1,13 +1,13 @@
 {
   "folder": "Material_AlphaMask",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf"
+    "Material_AlphaMask_00.gltf",
+    "Material_AlphaMask_01.gltf",
+    "Material_AlphaMask_02.gltf",
+    "Material_AlphaMask_03.gltf",
+    "Material_AlphaMask_04.gltf",
+    "Material_AlphaMask_05.gltf",
+    "Material_AlphaMask_06.gltf",
+    "Material_AlphaMask_07.gltf"
   ]
 }

--- a/Output/Material_Doublesided/Manifest.json
+++ b/Output/Material_Doublesided/Manifest.json
@@ -1,9 +1,9 @@
 {
   "folder": "Material_Doublesided",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf"
+    "Material_Doublesided_00.gltf",
+    "Material_Doublesided_01.gltf",
+    "Material_Doublesided_02.gltf",
+    "Material_Doublesided_03.gltf"
   ]
 }

--- a/Output/Material_MetallicRoughness/Manifest.json
+++ b/Output/Material_MetallicRoughness/Manifest.json
@@ -1,16 +1,16 @@
 {
   "folder": "Material_MetallicRoughness",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf",
-    "09.gltf",
-    "10.gltf"
+    "Material_MetallicRoughness_00.gltf",
+    "Material_MetallicRoughness_01.gltf",
+    "Material_MetallicRoughness_02.gltf",
+    "Material_MetallicRoughness_03.gltf",
+    "Material_MetallicRoughness_04.gltf",
+    "Material_MetallicRoughness_05.gltf",
+    "Material_MetallicRoughness_06.gltf",
+    "Material_MetallicRoughness_07.gltf",
+    "Material_MetallicRoughness_08.gltf",
+    "Material_MetallicRoughness_09.gltf",
+    "Material_MetallicRoughness_10.gltf"
   ]
 }

--- a/Output/Material_Mixed/Manifest.json
+++ b/Output/Material_Mixed/Manifest.json
@@ -1,8 +1,8 @@
 {
   "folder": "Material_Mixed",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf"
+    "Material_Mixed_00.gltf",
+    "Material_Mixed_01.gltf",
+    "Material_Mixed_02.gltf"
   ]
 }

--- a/Output/Material_SpecularGlossiness/Manifest.json
+++ b/Output/Material_SpecularGlossiness/Manifest.json
@@ -1,18 +1,18 @@
 {
   "folder": "Material_SpecularGlossiness",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf",
-    "09.gltf",
-    "10.gltf",
-    "11.gltf",
-    "12.gltf"
+    "Material_SpecularGlossiness_00.gltf",
+    "Material_SpecularGlossiness_01.gltf",
+    "Material_SpecularGlossiness_02.gltf",
+    "Material_SpecularGlossiness_03.gltf",
+    "Material_SpecularGlossiness_04.gltf",
+    "Material_SpecularGlossiness_05.gltf",
+    "Material_SpecularGlossiness_06.gltf",
+    "Material_SpecularGlossiness_07.gltf",
+    "Material_SpecularGlossiness_08.gltf",
+    "Material_SpecularGlossiness_09.gltf",
+    "Material_SpecularGlossiness_10.gltf",
+    "Material_SpecularGlossiness_11.gltf",
+    "Material_SpecularGlossiness_12.gltf"
   ]
 }

--- a/Output/Mesh_Indices/Manifest.json
+++ b/Output/Mesh_Indices/Manifest.json
@@ -1,21 +1,21 @@
 {
   "folder": "Mesh_Indices",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf",
-    "09.gltf",
-    "10.gltf",
-    "11.gltf",
-    "12.gltf",
-    "13.gltf",
-    "14.gltf",
-    "15.gltf"
+    "Mesh_Indices_00.gltf",
+    "Mesh_Indices_01.gltf",
+    "Mesh_Indices_02.gltf",
+    "Mesh_Indices_03.gltf",
+    "Mesh_Indices_04.gltf",
+    "Mesh_Indices_05.gltf",
+    "Mesh_Indices_06.gltf",
+    "Mesh_Indices_07.gltf",
+    "Mesh_Indices_08.gltf",
+    "Mesh_Indices_09.gltf",
+    "Mesh_Indices_10.gltf",
+    "Mesh_Indices_11.gltf",
+    "Mesh_Indices_12.gltf",
+    "Mesh_Indices_13.gltf",
+    "Mesh_Indices_14.gltf",
+    "Mesh_Indices_15.gltf"
   ]
 }

--- a/Output/Mesh_Primitives/Manifest.json
+++ b/Output/Mesh_Primitives/Manifest.json
@@ -1,11 +1,11 @@
 {
   "folder": "Mesh_Primitives",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf"
+    "Mesh_Primitives_00.gltf",
+    "Mesh_Primitives_01.gltf",
+    "Mesh_Primitives_02.gltf",
+    "Mesh_Primitives_03.gltf",
+    "Mesh_Primitives_04.gltf",
+    "Mesh_Primitives_05.gltf"
   ]
 }

--- a/Output/Mesh_PrimitivesUV/Manifest.json
+++ b/Output/Mesh_PrimitivesUV/Manifest.json
@@ -1,14 +1,14 @@
 {
   "folder": "Mesh_PrimitivesUV",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf"
+    "Mesh_PrimitivesUV_00.gltf",
+    "Mesh_PrimitivesUV_01.gltf",
+    "Mesh_PrimitivesUV_02.gltf",
+    "Mesh_PrimitivesUV_03.gltf",
+    "Mesh_PrimitivesUV_04.gltf",
+    "Mesh_PrimitivesUV_05.gltf",
+    "Mesh_PrimitivesUV_06.gltf",
+    "Mesh_PrimitivesUV_07.gltf",
+    "Mesh_PrimitivesUV_08.gltf"
   ]
 }

--- a/Output/Node_Attribute/Manifest.json
+++ b/Output/Node_Attribute/Manifest.json
@@ -1,14 +1,14 @@
 {
   "folder": "Node_Attribute",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf"
+    "Node_Attribute_00.gltf",
+    "Node_Attribute_01.gltf",
+    "Node_Attribute_02.gltf",
+    "Node_Attribute_03.gltf",
+    "Node_Attribute_04.gltf",
+    "Node_Attribute_05.gltf",
+    "Node_Attribute_06.gltf",
+    "Node_Attribute_07.gltf",
+    "Node_Attribute_08.gltf"
   ]
 }

--- a/Output/Node_NegativeScale/Manifest.json
+++ b/Output/Node_NegativeScale/Manifest.json
@@ -1,14 +1,14 @@
 {
   "folder": "Node_NegativeScale",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf"
+    "Node_NegativeScale_00.gltf",
+    "Node_NegativeScale_01.gltf",
+    "Node_NegativeScale_02.gltf",
+    "Node_NegativeScale_03.gltf",
+    "Node_NegativeScale_04.gltf",
+    "Node_NegativeScale_05.gltf",
+    "Node_NegativeScale_06.gltf",
+    "Node_NegativeScale_07.gltf",
+    "Node_NegativeScale_08.gltf"
   ]
 }

--- a/Output/Primitive_Attribute/Manifest.json
+++ b/Output/Primitive_Attribute/Manifest.json
@@ -1,13 +1,13 @@
 {
   "folder": "Primitive_Attribute",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf"
+    "Primitive_Attribute_00.gltf",
+    "Primitive_Attribute_01.gltf",
+    "Primitive_Attribute_02.gltf",
+    "Primitive_Attribute_03.gltf",
+    "Primitive_Attribute_04.gltf",
+    "Primitive_Attribute_05.gltf",
+    "Primitive_Attribute_06.gltf",
+    "Primitive_Attribute_07.gltf"
   ]
 }

--- a/Output/Primitive_VertexColor/Manifest.json
+++ b/Output/Primitive_VertexColor/Manifest.json
@@ -1,11 +1,11 @@
 {
   "folder": "Primitive_VertexColor",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf"
+    "Primitive_VertexColor_00.gltf",
+    "Primitive_VertexColor_01.gltf",
+    "Primitive_VertexColor_02.gltf",
+    "Primitive_VertexColor_03.gltf",
+    "Primitive_VertexColor_04.gltf",
+    "Primitive_VertexColor_05.gltf"
   ]
 }

--- a/Output/Texture_Sampler/Manifest.json
+++ b/Output/Texture_Sampler/Manifest.json
@@ -1,19 +1,19 @@
 {
   "folder": "Texture_Sampler",
   "files": [
-    "00.gltf",
-    "01.gltf",
-    "02.gltf",
-    "03.gltf",
-    "04.gltf",
-    "05.gltf",
-    "06.gltf",
-    "07.gltf",
-    "08.gltf",
-    "09.gltf",
-    "10.gltf",
-    "11.gltf",
-    "12.gltf",
-    "13.gltf"
+    "Texture_Sampler_00.gltf",
+    "Texture_Sampler_01.gltf",
+    "Texture_Sampler_02.gltf",
+    "Texture_Sampler_03.gltf",
+    "Texture_Sampler_04.gltf",
+    "Texture_Sampler_05.gltf",
+    "Texture_Sampler_06.gltf",
+    "Texture_Sampler_07.gltf",
+    "Texture_Sampler_08.gltf",
+    "Texture_Sampler_09.gltf",
+    "Texture_Sampler_10.gltf",
+    "Texture_Sampler_11.gltf",
+    "Texture_Sampler_12.gltf",
+    "Texture_Sampler_13.gltf"
   ]
 }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -96,8 +96,8 @@ namespace AssetGenerator
                     modelGroup.PostRuntimeChanges(combos[comboIndex], ref gltf);
 
                     // Creates the .gltf file and writes the model's data to it
-                    var filename = comboIndex.ToString("00") + ".gltf";
-                    var assetFile = Path.Combine(assetFolder, modelGroup.modelGroupName.ToString() + "_" + filename);
+                    var filename = modelGroup.modelGroupName.ToString() + "_" + comboIndex.ToString("00") + ".gltf";
+                    var assetFile = Path.Combine(assetFolder, filename);
                     glTFLoader.Interface.SaveModel(gltf, assetFile);
 
                     // Creates the .bin file and writes the model's data to it
@@ -110,7 +110,7 @@ namespace AssetGenerator
                     }
 
                     readme.SetupTable(modelGroup, comboIndex, combos);
-                    manifest.files.Add(Path.GetFileName(assetFile));
+                    manifest.files.Add(filename);
                 }
 
                 readme.WriteOut(executingAssembly, modelGroup, assetFolder);

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -110,7 +110,7 @@ namespace AssetGenerator
                     }
 
                     readme.SetupTable(modelGroup, comboIndex, combos);
-                    manifest.files.Add(filename);
+                    manifest.files.Add(Path.GetFileName(assetFile));
                 }
 
                 readme.WriteOut(executingAssembly, modelGroup, assetFolder);


### PR DESCRIPTION
Change the manifests to use the full file name instead of only the file number.

Fix for #343 