### PR TITLE
Add support for assigning custom camera properties per model group in the manifest

### DIFF
--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
-using System.Text.RegularExpressions;
-using System.IO;
+using System;
 
 namespace AssetGenerator
 {
@@ -10,11 +9,13 @@ namespace AssetGenerator
         public string folder;
         public List<Model> models = new List<Model>();
 
+        // Model group, to be listed in the manifest as the folder name
         public Manifest(ModelGroupName name)
         {
             folder = name.ToString();
         }
 
+        // Model properties to be listed in the manifest
         public class Model
         {
             public string fileName;
@@ -22,25 +23,97 @@ namespace AssetGenerator
             public string sampleThumbnailName;
             public Camera camera;
 
-            public Model(string name, Vector3 trans, Vector4 rot)
+            public Model(string name, ModelGroupName modelGroupName)
             {
                 fileName = name;
                 sampleImageName = "SampleImages" + '/' + name.Replace(".gltf", ".png");
                 sampleThumbnailName = "Thumbnails" + '/' + name.Replace(".gltf", ".png");
-                camera = new Camera(trans, rot);
+                camera = CustomCameraList.GetCamera(modelGroupName);
             }
         }
 
+        // Camera properties
         public class Camera
         {
             public float[] translation = new float[3];
             public float[] rotation = new float[4];
 
-            public Camera(Vector3 trans, Vector4 rot)
+            public Camera(Vector3 cameratranslation, Vector4 cameraRotation)
             {
-                trans.CopyTo(translation);
-                rot.CopyTo(rotation);
+                cameratranslation.CopyTo(translation);
+                cameraRotation.CopyTo(rotation);
             }
+        }
+
+        // Used to track camera properties for model groups that need a custom camera
+        internal static class CustomCameraList
+        {
+            internal static List<ModelCameraPairing> customCameraList;
+
+            internal class ModelCameraPairing
+            {
+                internal Camera camera;
+                internal ModelGroupName modelGroup;
+
+                internal ModelCameraPairing(Camera cameraSettings, ModelGroupName name)
+                {
+                    camera = cameraSettings;
+                    modelGroup = name;
+                }
+            }
+
+            internal static Camera GetCamera(ModelGroupName modelGroup)
+            {
+                // Checks if the list has been initialized, so it isn't recreated multiple times.
+                if (customCameraList == null)
+                {
+                    BuildCameraParings();
+                }
+
+                // Searches the list for a matching custom camera
+                var custom = customCameraList.Find(e => e.modelGroup == modelGroup);
+                Camera camera;
+
+                // Use the custom camera if it is found, otherwise use the default camera
+                if (custom == null)
+                {
+                    camera = customCameraList[0].camera;
+                }
+                else
+                {
+                    camera = custom.camera;
+                }
+
+                return camera;
+            }
+
+            internal static void BuildCameraParings()
+            {
+                customCameraList = new List<ModelCameraPairing>();
+
+                // Default camera position. Keep this in the first position on the list.
+                customCameraList.Add(
+                    new ModelCameraPairing(
+                        new Camera(new Vector3((float)Math.PI / 2, (float)Math.PI / 2, -1.3f), new Vector4(0, 0, 0, 1)),
+                        ModelGroupName.Undefined)
+                        );
+
+
+                // Node_Attribute
+                customCameraList.Add(
+                    new ModelCameraPairing(
+                        new Camera(new Vector3((float)Math.PI / 2, (float)Math.PI / 2, -1.3f), new Vector4(0, 0, 0, 1)),
+                        ModelGroupName.Node_Attribute)
+                        );
+
+                // Node_NegativeScale
+                customCameraList.Add(
+                    new ModelCameraPairing(
+                        new Camera(new Vector3((float)Math.PI / 2, (float)Math.PI / 2, -1.3f), new Vector4(0, 0, 0, 1)),
+                        ModelGroupName.Node_NegativeScale)
+                        );
+            }
+           
         }
     }
 }

--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -87,6 +87,11 @@ namespace AssetGenerator
                 return camera;
             }
 
+            /// <summary>
+            ///  Contains the values used for the camera when creating sample images of the models. They all use the first
+            ///  by default, but adding in another section below will cause all models in that model group to use that camera.
+            ///  This is the only section that will need to be changed when needing to use a custom camera for the sample images.
+            /// </summary>
             internal static void BuildCameraParings()
             {
                 customCameraList = new List<ModelCameraPairing>();
@@ -97,7 +102,6 @@ namespace AssetGenerator
                         new Camera(new Vector3((float)Math.PI / 2, (float)Math.PI / 2, -1.3f), new Vector4(0, 0, 0, 1)),
                         ModelGroupName.Undefined)
                         );
-
 
                 // Node_Attribute
                 customCameraList.Add(

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -112,10 +112,7 @@ namespace AssetGenerator
 
                     readme.SetupTable(modelGroup, comboIndex, combos);
                     manifest.models.Add(
-                        new Manifest.Model(
-                            filename, 
-                            new System.Numerics.Vector3((float)Math.PI / 2, (float)Math.PI / 2, -1.3f), 
-                            new System.Numerics.Vector4(0, 0, 0, 1)));
+                        new Manifest.Model(filename, modelGroup.modelGroupName));
                 }
 
                 readme.WriteOut(executingAssembly, modelGroup, assetFolder);


### PR DESCRIPTION
Instead of using a static camera properties for every model, we can now assign them per model group. 

Currently every model is receiving the same properties, but I've added in two sections for Node_Attribute and Node_NegativeScale that can be switched out for the desired properties.