### PR TITLE
Remove automatic combos from the Material modelgroup

### DIFF
--- a/Output/Material/Material_06.gltf
+++ b/Output/Material/Material_06.gltf
@@ -36,7 +36,7 @@
     "generator": "glTF Asset Generator",
     "version": "2.0",
     "extras": {
-      "Attributes": "EmissiveFactor - EmissiveTexture"
+      "Attributes": "EmissiveTexture - EmissiveFactor"
     }
   },
   "buffers": [

--- a/Source/ModelGroup.cs
+++ b/Source/ModelGroup.cs
@@ -16,6 +16,7 @@ namespace AssetGenerator
         public bool noPrerequisite = true;
         public int id = -1;
         public bool noSampleImages = false;
+        public List<List<Property>> combos = new List<List<Property>>();
 
         public ModelGroup(List<string> figures)
         {

--- a/Source/ModelGroups/Material.cs
+++ b/Source/ModelGroups/Material.cs
@@ -11,21 +11,23 @@ namespace AssetGenerator.ModelGroups
             modelGroupName = ModelGroupName.Material;
             onlyBinaryProperties = false;
             noPrerequisite = false;
+
             Runtime.Image emissiveTexture = new Runtime.Image
             {
-                Uri = imageList.Find(e => e.Contains("Emissive_Plane"))
+                Uri = imageList.Find(e => e.Contains("Textures/Emissive_Plane")).Replace("Resources/", "")
             };
             Runtime.Image normalTexture = new Runtime.Image
             {
-                Uri = imageList.Find(e => e.Contains("Normal_Plane"))
-    };
+                Uri = imageList.Find(e => e.Contains("Textures/Normal_Plane")).Replace("Resources/", "")
+            };
             Runtime.Image occlusionTexture = new Runtime.Image
             {
-                Uri = imageList.Find(e => e.Contains("Occlusion_Plane"))
-};
+                Uri = imageList.Find(e => e.Contains("Textures/Occlusion_Plane")).Replace("Resources/", "")
+            };
             usedTextures.Add(emissiveTexture);
             usedTextures.Add(normalTexture);
             usedTextures.Add(occlusionTexture);
+
             List<Vector3> planeNormals = new List<Vector3>()
             {
                 new Vector3( 0.0f, 0.0f,1.0f),
@@ -33,67 +35,77 @@ namespace AssetGenerator.ModelGroups
                 new Vector3( 0.0f, 0.0f,1.0f),
                 new Vector3( 0.0f, 0.0f,1.0f)
             };
+
             requiredProperty = new List<Property>
             {
                 new Property(Propertyname.MetallicFactor, 0.0f),
                 new Property(Propertyname.BaseColorFactor, new Vector4(0.2f, 0.2f, 0.2f, 1.0f)),
             };
-            properties = new List<Property>
-            {
-                new Property(Propertyname.NormalTexture, normalTexture),
-                new Property(Propertyname.Scale, 10.0f, Propertyname.NormalTexture),
-                new Property(Propertyname.OcclusionTexture, occlusionTexture),
-                new Property(Propertyname.Strength, 0.5f, Propertyname.OcclusionTexture),
-                new Property(Propertyname.EmissiveTexture, emissiveTexture),
-                new Property(Propertyname.EmissiveFactor, new Vector3(1.0f, 1.0f, 1.0f)),
-            };
             specialProperties = new List<Property>
             {
                 new Property(Propertyname.VertexNormal, planeNormals),
             };
-            specialCombos.Add(ComboHelper.CustomComboCreation(
-                properties.Find(e => e.name == Propertyname.EmissiveFactor),
-                properties.Find(e => e.name == Propertyname.EmissiveTexture)));
-            removeCombos.Add(ComboHelper.CustomComboCreation(
-                properties.Find(e => e.name == Propertyname.EmissiveTexture)));
-        }
 
-        override public List<List<Property>> ApplySpecialProperties(ModelGroup test, List<List<Property>> combos)
-        {
-            // Sort the combos by complexity
-            combos.Sort(delegate (List<Property> x, List<Property> y)
+            // Declares the properties and their values. Order doesn't matter here
+            Property normalTextureProperty = new Property(Propertyname.NormalTexture, normalTexture);
+            Property scale = new Property(Propertyname.Scale, 10.0f, Propertyname.NormalTexture);
+            Property occlusionTextureProperty = new Property(Propertyname.OcclusionTexture, occlusionTexture);
+            Property strength = new Property(Propertyname.Strength, 0.5f, Propertyname.OcclusionTexture);
+            Property emissiveTextureProperty = new Property(Propertyname.EmissiveTexture, emissiveTexture);
+            Property emissiveFactor = new Property(Propertyname.EmissiveFactor, new Vector3(1.0f, 1.0f, 1.0f));
+
+            // Declares the list of properties. The order here determins the column order.
+            properties = new List<Property>
             {
-                if (x.Count == 0) return -1; // Empty Set
-                else if (y.Count == 0) return 1; // Empty Set
-                else if (x.Count > y.Count) return 1;
-                else if (x.Count < y.Count) return -1;
-                else if (x.Count == y.Count)
-                {
-                    // Tie goes to the combo with the left-most property on the table
-                    for (int p = 0; p < x.Count; p++)
-                    {
-                        if (x[p].propertyGroup != y[p].propertyGroup ||
-                            x[p].propertyGroup == 0)
-                        {
-                            int xPropertyIndex = properties.FindIndex(e => e.name == x[p].name);
-                            int yPropertyIndex = properties.FindIndex(e => e.name == y[p].name);
-                            if (xPropertyIndex > yPropertyIndex) return 1;
-                            else if (xPropertyIndex < yPropertyIndex) return -1;
-                        }
-                    }
-                    for (int p = 0; p < x.Count; p++)
-                    {
-                        int xPropertyIndex = properties.FindIndex(e => e.name == x[p].name);
-                        int yPropertyIndex = properties.FindIndex(e => e.name == y[p].name);
-                        if (xPropertyIndex > yPropertyIndex) return 1;
-                        else if (xPropertyIndex < yPropertyIndex) return -1;
-                    }
-                    return 0;
-                }
-                else return 0;
-            });
+                normalTextureProperty,
+                scale,
+                occlusionTextureProperty,
+                strength,
+                emissiveTextureProperty,
+                emissiveFactor
+            };
 
-            return combos;
+            // Declares the combos. The order here determines the number for the model (assending order) and the order that the properties are applied to a model.
+            combos.Add(new List<Property>()
+            {
+
+            });
+            combos.Add(new List<Property>()
+            {
+                normalTextureProperty
+            });
+            combos.Add(new List<Property>()
+            {
+                occlusionTextureProperty
+            });
+            combos.Add(new List<Property>()
+            {
+                emissiveFactor
+            });
+            combos.Add(new List<Property>()
+            {
+                normalTextureProperty,
+                scale
+            });
+            combos.Add(new List<Property>()
+            {
+                occlusionTextureProperty,
+                strength
+            });
+            combos.Add(new List<Property>()
+            {
+                emissiveTextureProperty,
+                emissiveFactor
+            });
+            combos.Add(new List<Property>()
+            {
+                normalTextureProperty,
+                scale,
+                occlusionTextureProperty,
+                strength,
+                emissiveTextureProperty,
+                emissiveFactor
+            });
         }
 
         public Runtime.GLTF SetModelAttributes(Runtime.GLTF wrapper, Runtime.Material material, List<Property> combo, ref glTFLoader.Schema.Gltf gltf)

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -37,7 +37,11 @@ namespace AssetGenerator
             var modelGroupIndex = 0;
             foreach (var modelGroup in allModelGroups)
             {
-                List<List<Property>> combos = ComboHelper.AttributeCombos(modelGroup);
+                // Creates the combos if the model group is still using automatic combos
+                if (modelGroup.combos.Count < 1)
+                {
+                    modelGroup.combos = ComboHelper.AttributeCombos(modelGroup);
+                }
 
                 ReadmeBuilder readme = new ReadmeBuilder();
                 modelGroup.id = modelGroupIndex++;
@@ -54,10 +58,10 @@ namespace AssetGenerator
 
                 readme.SetupHeader(modelGroup);
 
-                int numCombos = combos.Count;
+                int numCombos = modelGroup.combos.Count;
                 for (int comboIndex = 0; comboIndex < numCombos; comboIndex++)
                 {
-                    string[] name = ReadmeStringHelper.GenerateName(combos[comboIndex]);
+                    string[] name = ReadmeStringHelper.GenerateName(modelGroup.combos[comboIndex]);
 
                     var asset = new Runtime.Asset
                     {
@@ -87,7 +91,7 @@ namespace AssetGenerator
                     Runtime.Material mat = new Runtime.Material();
 
                     // Takes the current combo and uses it to bundle together the data for the desired properties 
-                    wrapper = modelGroup.SetModelAttributes(wrapper, mat, combos[comboIndex], ref gltf);
+                    wrapper = modelGroup.SetModelAttributes(wrapper, mat, modelGroup.combos[comboIndex], ref gltf);
 
                     // Passes the desired properties to the runtime layer, which then coverts that data into
                     // a gltf loader object, ready to create the model
@@ -95,7 +99,7 @@ namespace AssetGenerator
 
                     // Makes last second changes to the model that bypass the runtime layer
                     // in order to add 'features that don't really exist otherwise
-                    modelGroup.PostRuntimeChanges(combos[comboIndex], ref gltf);
+                    modelGroup.PostRuntimeChanges(modelGroup.combos[comboIndex], ref gltf);
 
                     // Creates the .gltf file and writes the model's data to it
                     var filename = modelGroup.modelGroupName.ToString() + "_" + comboIndex.ToString("00") + ".gltf";
@@ -111,7 +115,7 @@ namespace AssetGenerator
                         File.WriteAllBytes(dataFile, ((MemoryStream)data.Writer.BaseStream).ToArray());
                     }
 
-                    readme.SetupTable(modelGroup, comboIndex, combos);
+                    readme.SetupTable(modelGroup, comboIndex, modelGroup.combos);
                     manifest.models.Add(
                         new Manifest.Model(filename, modelGroup.modelGroupName, modelGroup.noSampleImages));
                 }


### PR DESCRIPTION
This PR is more to show what I have in mind. Progress on issue #394 

There is no sorting being done or automatic combos on the Material modelgroup with this change. Once this has been implemented to all of the model groups I'll be removing the ComboHelper class entirely.