### PR TITLE
Remove the Id property from ModelGroup

### DIFF
--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -9,7 +9,7 @@ namespace AssetGenerator
         public List<Model> Models = new List<Model>();
 
         // Model group, to be listed in the manifest as the folder name
-        public Manifest(ModelGroupName name)
+        public Manifest(ModelGroupId name)
         {
             Folder = name.ToString();
         }
@@ -22,7 +22,7 @@ namespace AssetGenerator
             public string SampleImageName;
             public Camera Camera;
 
-            public Model(string name, ModelGroupName modelGroupName, bool noSampleImages)
+            public Model(string name, ModelGroupId modelGroupName, bool noSampleImages)
             {
                 FileName = name;
                 if (noSampleImages == false)
@@ -52,16 +52,16 @@ namespace AssetGenerator
             public class ModelCameraPairing
             {
                 public Camera camera;
-                public ModelGroupName? modelGroup;
+                public ModelGroupId? modelGroup;
 
-                public ModelCameraPairing(Camera cameraSettings, ModelGroupName? name)
+                public ModelCameraPairing(Camera cameraSettings, ModelGroupId? name)
                 {
                     camera = cameraSettings;
                     modelGroup = name;
                 }
             }
 
-            public static Camera GetCamera(ModelGroupName modelGroup)
+            public static Camera GetCamera(ModelGroupId modelGroup)
             {
                 // Checks if the list has been initialized, so it isn't recreated multiple times.
                 if (customCameras == null)
@@ -106,14 +106,14 @@ namespace AssetGenerator
                 customCameras.Add(
                     new ModelCameraPairing(
                         new Camera(new Vector3(0, 20, -20)),
-                        ModelGroupName.Node_Attribute)
+                        ModelGroupId.Node_Attribute)
                         );
 
                 // Node_NegativeScale
                 customCameras.Add(
                     new ModelCameraPairing(
                         new Camera(new Vector3(0, 20, -20)),
-                        ModelGroupName.Node_NegativeScale)
+                        ModelGroupId.Node_NegativeScale)
                         );
             }
         }

--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -9,9 +9,9 @@ namespace AssetGenerator
         public List<Model> Models = new List<Model>();
 
         // Model group, to be listed in the manifest as the folder name
-        public Manifest(ModelGroupId name)
+        public Manifest(ModelGroupId modelGroupId)
         {
-            Folder = name.ToString();
+            Folder = modelGroupId.ToString();
         }
 
         // Model properties to be listed in the manifest
@@ -22,14 +22,14 @@ namespace AssetGenerator
             public string SampleImageName;
             public Camera Camera;
 
-            public Model(string name, ModelGroupId modelGroupName, bool noSampleImages)
+            public Model(string name, ModelGroupId modelGroupId, bool noSampleImages)
             {
                 FileName = name;
                 if (noSampleImages == false)
                 {
                     SampleImageName = "Figures/SampleImages" + '/' + name.Replace(".gltf", ".png");
                 }
-                Camera = CustomCameraList.GetCamera(modelGroupName);
+                Camera = CustomCameraList.GetCamera(modelGroupId);
             }
         }
 
@@ -54,10 +54,10 @@ namespace AssetGenerator
                 public Camera camera;
                 public ModelGroupId? modelGroup;
 
-                public ModelCameraPairing(Camera cameraSettings, ModelGroupId? name)
+                public ModelCameraPairing(Camera cameraSettings, ModelGroupId? modelGroupId)
                 {
                     camera = cameraSettings;
-                    modelGroup = name;
+                    modelGroup = modelGroupId;
                 }
             }
 

--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -52,9 +52,9 @@ namespace AssetGenerator
             public class ModelCameraPairing
             {
                 public Camera camera;
-                public ModelGroupName modelGroup;
+                public ModelGroupName? modelGroup;
 
-                public ModelCameraPairing(Camera cameraSettings, ModelGroupName name)
+                public ModelCameraPairing(Camera cameraSettings, ModelGroupName? name)
                 {
                     camera = cameraSettings;
                     modelGroup = name;
@@ -99,7 +99,7 @@ namespace AssetGenerator
                 customCameras.Add(
                     new ModelCameraPairing(
                         new Camera(new Vector3(0, 0, 1.3f)),
-                        ModelGroupName.Undefined)
+                        null)
                         );
 
                 // Node_Attribute

--- a/Source/ModelGroup.cs
+++ b/Source/ModelGroup.cs
@@ -7,7 +7,7 @@ namespace AssetGenerator
 {
     internal abstract partial class ModelGroup
     {
-        public abstract ModelGroupName Name { get; }
+        public abstract ModelGroupId Id { get; }
         public List<Model> Models { get; protected set; }
         public List<Property> CommonProperties { get; private set; }
         public List<Property> Properties { get; private set; }
@@ -206,7 +206,7 @@ namespace AssetGenerator
         public Func<Type, object> CreateSchemaInstance = Activator.CreateInstance;
     }
 
-    internal enum ModelGroupName
+    internal enum ModelGroupId
     {
         Buffer_Interleaved,
         Compatibility,

--- a/Source/ModelGroup.cs
+++ b/Source/ModelGroup.cs
@@ -13,7 +13,6 @@ namespace AssetGenerator
         public List<Property> Properties { get; private set; }
         public List<Runtime.Image> UsedTextures { get; private set; }
         public List<Runtime.Image> UsedFigures { get; private set; }
-        public int Id { get; set; }
         public bool NoSampleImages { get; protected set; }
 
         protected ModelGroup()
@@ -209,24 +208,22 @@ namespace AssetGenerator
 
     internal enum ModelGroupName
     {
-        Undefined,
         Buffer_Interleaved,
         Compatibility,
         Material,
-        Material_AlphaMask,
         Material_AlphaBlend,
+        Material_AlphaMask,
         Material_DoubleSided,
         Material_MetallicRoughness,
-        Material_SpecularGlossiness,
         Material_Mixed,
+        Material_SpecularGlossiness,
         Mesh_PrimitiveAttribute,
-        Mesh_PrimitiveVertexColor,
         Mesh_PrimitiveMode,
+        Mesh_PrimitiveVertexColor,
         Mesh_Primitives,
         Mesh_PrimitivesUV,
-        Node_NegativeScale,
         Node_Attribute,
+        Node_NegativeScale,
         Texture_Sampler,
-        Primitive_VertexColor,
     }
 }

--- a/Source/ModelGroups/Buffer_Interleaved.cs
+++ b/Source/ModelGroups/Buffer_Interleaved.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Buffer_Interleaved : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Buffer_Interleaved;
+        public override ModelGroupId Id => ModelGroupId.Buffer_Interleaved;
 
         public Buffer_Interleaved(List<string> imageList)
         {

--- a/Source/ModelGroups/Compatibility.cs
+++ b/Source/ModelGroups/Compatibility.cs
@@ -10,7 +10,7 @@ namespace AssetGenerator
 {
     internal class Compatibility : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Compatibility;
+        public override ModelGroupId Id => ModelGroupId.Compatibility;
 
         public Compatibility(List<string> imageList)
         {

--- a/Source/ModelGroups/Material.cs
+++ b/Source/ModelGroups/Material.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material;
+        public override ModelGroupId Id => ModelGroupId.Material;
 
         public Material(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_AlphaBlend.cs
+++ b/Source/ModelGroups/Material_AlphaBlend.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material_AlphaBlend : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_AlphaBlend;
+        public override ModelGroupId Id => ModelGroupId.Material_AlphaBlend;
 
         public Material_AlphaBlend(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_AlphaMask.cs
+++ b/Source/ModelGroups/Material_AlphaMask.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material_AlphaMask : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_AlphaMask;
+        public override ModelGroupId Id => ModelGroupId.Material_AlphaMask;
 
         public Material_AlphaMask(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_DoubleSided.cs
+++ b/Source/ModelGroups/Material_DoubleSided.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material_DoubleSided : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_DoubleSided;
+        public override ModelGroupId Id => ModelGroupId.Material_DoubleSided;
 
         public Material_DoubleSided(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_MetallicRoughness.cs
+++ b/Source/ModelGroups/Material_MetallicRoughness.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material_MetallicRoughness : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_MetallicRoughness;
+        public override ModelGroupId Id => ModelGroupId.Material_MetallicRoughness;
 
         public Material_MetallicRoughness(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_Mixed.cs
+++ b/Source/ModelGroups/Material_Mixed.cs
@@ -5,7 +5,7 @@ namespace AssetGenerator
 {
     internal class Material_Mixed : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_Mixed;
+        public override ModelGroupId Id => ModelGroupId.Material_Mixed;
 
         public Material_Mixed(List<string> imageList)
         {

--- a/Source/ModelGroups/Material_SpecularGlossiness.cs
+++ b/Source/ModelGroups/Material_SpecularGlossiness.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Material_SpecularGlossiness : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Material_SpecularGlossiness;
+        public override ModelGroupId Id => ModelGroupId.Material_SpecularGlossiness;
 
         public Material_SpecularGlossiness(List<string> imageList)
         {

--- a/Source/ModelGroups/Mesh_PrimitiveAttribute.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveAttribute.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Mesh_PrimitiveAttribute : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Mesh_PrimitiveAttribute;
+        public override ModelGroupId Id => ModelGroupId.Mesh_PrimitiveAttribute;
 
         public Mesh_PrimitiveAttribute(List<string> imageList)
         {

--- a/Source/ModelGroups/Mesh_PrimitiveMode.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveMode.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Mesh_PrimitiveMode : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Mesh_PrimitiveMode;
+        public override ModelGroupId Id => ModelGroupId.Mesh_PrimitiveMode;
 
         public Mesh_PrimitiveMode(List<string> imageList)
         {

--- a/Source/ModelGroups/Mesh_PrimitiveVertexColor.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveVertexColor.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Mesh_PrimitiveVertexColor : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Mesh_PrimitiveVertexColor;
+        public override ModelGroupId Id => ModelGroupId.Mesh_PrimitiveVertexColor;
 
         public Mesh_PrimitiveVertexColor(List<string> imageList)
         {

--- a/Source/ModelGroups/Mesh_Primitives.cs
+++ b/Source/ModelGroups/Mesh_Primitives.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Mesh_Primitives : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Mesh_Primitives;
+        public override ModelGroupId Id => ModelGroupId.Mesh_Primitives;
 
         public Mesh_Primitives(List<string> imageList)
         {

--- a/Source/ModelGroups/Mesh_PrimitivesUV.cs
+++ b/Source/ModelGroups/Mesh_PrimitivesUV.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Mesh_PrimitivesUV : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Mesh_PrimitivesUV;
+        public override ModelGroupId Id => ModelGroupId.Mesh_PrimitivesUV;
 
         public Mesh_PrimitivesUV(List<string> imageList)
         {

--- a/Source/ModelGroups/Node_Attribute.cs
+++ b/Source/ModelGroups/Node_Attribute.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Node_Attribute : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Node_Attribute;
+        public override ModelGroupId Id => ModelGroupId.Node_Attribute;
 
         public Node_Attribute(List<string> imageList)
         {

--- a/Source/ModelGroups/Node_NegativeScale.cs
+++ b/Source/ModelGroups/Node_NegativeScale.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Node_NegativeScale : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Node_NegativeScale;
+        public override ModelGroupId Id => ModelGroupId.Node_NegativeScale;
 
         public Node_NegativeScale(List<string> imageList)
         {

--- a/Source/ModelGroups/Texture_Sampler.cs
+++ b/Source/ModelGroups/Texture_Sampler.cs
@@ -6,7 +6,7 @@ namespace AssetGenerator
 {
     internal class Texture_Sampler : ModelGroup
     {
-        public override ModelGroupName Name => ModelGroupName.Texture_Sampler;
+        public override ModelGroupId Id => ModelGroupId.Texture_Sampler;
 
         public Texture_Sampler(List<string> imageList)
         {

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -51,9 +51,9 @@ namespace AssetGenerator
             foreach (var modelGroup in allModelGroups)
             {
                 ReadmeBuilder readme = new ReadmeBuilder();
-                Manifest manifest = new Manifest(modelGroup.Name);
+                Manifest manifest = new Manifest(modelGroup.Id);
               
-                string modelGroupFolder = Path.Combine(outputFolder, modelGroup.Name.ToString());
+                string modelGroupFolder = Path.Combine(outputFolder, modelGroup.Id.ToString());
 
                 Directory.CreateDirectory(modelGroupFolder);
 
@@ -67,9 +67,9 @@ namespace AssetGenerator
                 for (int comboIndex = 0; comboIndex < numCombos; comboIndex++)
                 {
                     var model = modelGroup.Models[comboIndex];
-                    var filename = $"{modelGroup.Name}_{comboIndex:00}.gltf";
+                    var filename = $"{modelGroup.Id}_{comboIndex:00}.gltf";
 
-                    using (var data = new Data($"{modelGroup.Name}_{comboIndex:00}.bin"))
+                    using (var data = new Data($"{modelGroup.Id}_{comboIndex:00}.bin"))
                     {
                         // Passes the desired properties to the runtime layer, which then coverts that data into
                         // a gltf loader object, ready to create the model
@@ -90,7 +90,7 @@ namespace AssetGenerator
                     }
 
                     readme.SetupTable(modelGroup, comboIndex, model.Properties);
-                    manifest.Models.Add(new Manifest.Model(filename, modelGroup.Name, modelGroup.NoSampleImages));
+                    manifest.Models.Add(new Manifest.Model(filename, modelGroup.Id, modelGroup.NoSampleImages));
                 }
 
                 readme.WriteOut(executingAssembly, modelGroup, modelGroupFolder);

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -48,11 +48,9 @@ namespace AssetGenerator
                 new Texture_Sampler(imageList),
             };
 
-            var modelGroupIndex = 0;
             foreach (var modelGroup in allModelGroups)
             {
                 ReadmeBuilder readme = new ReadmeBuilder();
-                modelGroup.Id = modelGroupIndex++;
                 Manifest manifest = new Manifest(modelGroup.Name);
               
                 string modelGroupFolder = Path.Combine(outputFolder, modelGroup.Name.ToString());

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -161,7 +161,7 @@ namespace AssetGenerator
         public void WriteOut(Assembly executingAssembly, ModelGroup test, string assetFolder)
         {
             string template;
-            string templatePath = $"AssetGenerator.ReadmeTemplates.{test.Id.ToString()}.md";
+            string templatePath = $"AssetGenerator.ReadmeTemplates.{test.Id}.md";
 
             // Reads the template file
             using (Stream stream = executingAssembly.GetManifestResourceStream(templatePath))

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -121,7 +121,7 @@ namespace AssetGenerator
         {
             string modelGroupName = test.Name.ToString();
             string modelNumber = modelIndex.ToString("D2");
-            string liveURL = $"https://bghgary.github.io/glTF-Assets-Viewer/?folder={Convert.ToInt32(test.Name)}&model={modelIndex}";
+            string liveURL = $"https://bghgary.github.io/glTF-Assets-Viewer/?folder={test.Name:D}&model={modelIndex}";
 
             // Creates a new row for a new model
             List<string> modelInfo = new List<string>

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -121,7 +121,7 @@ namespace AssetGenerator
         {
             string modelGroupName = test.Name.ToString();
             string modelNumber = modelIndex.ToString("D2");
-            string liveURL = string.Format("https://bghgary.github.io/glTF-Assets-Viewer/?folder={0}&model={1}", test.Id, modelIndex);
+            string liveURL = $"https://bghgary.github.io/glTF-Assets-Viewer/?folder={Convert.ToInt32(test.Name)}&model={modelIndex}";
 
             // Creates a new row for a new model
             List<string> modelInfo = new List<string>

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -119,9 +119,9 @@ namespace AssetGenerator
         /// </summary>
         public void SetupTable(ModelGroup test, int modelIndex, List<Property> model)
         {
-            string modelGroupName = test.Name.ToString();
+            string modelGroupName = test.Id.ToString();
             string modelNumber = modelIndex.ToString("D2");
-            string liveURL = $"https://bghgary.github.io/glTF-Assets-Viewer/?folder={test.Name:D}&model={modelIndex}";
+            string liveURL = $"https://bghgary.github.io/glTF-Assets-Viewer/?folder={test.Id:D}&model={modelIndex}";
 
             // Creates a new row for a new model
             List<string> modelInfo = new List<string>
@@ -161,7 +161,7 @@ namespace AssetGenerator
         public void WriteOut(Assembly executingAssembly, ModelGroup test, string assetFolder)
         {
             string template;
-            string templatePath = $"AssetGenerator.ReadmeTemplates.{test.Name.ToString()}.md";
+            string templatePath = $"AssetGenerator.ReadmeTemplates.{test.Id.ToString()}.md";
 
             // Reads the template file
             using (Stream stream = executingAssembly.GetManifestResourceStream(templatePath))


### PR DESCRIPTION
Changes made to the manifest code and ModelGroupName enum were done to keep the existing order intact. Also removed a String.Format that hadn't been updated yet.

Fixes #413 