### PR TITLE
Rename VertexUV0 to TextureCoordinateComponentType

### DIFF
--- a/Output/Buffer_Interleaved/README.md
+++ b/Output/Buffer_Interleaved/README.md
@@ -11,7 +11,7 @@ The following table shows the properties that are set for every model.
 
 The following table shows the properties that are set for a given model.  
 
-|   | Sample Image | Vertex UV 0 | Vertex Color |
+|   | Sample Image | Texture Coordinate Component Type | Vertex Color |
 | :---: | :---: | :---: | :---: |
 | [00](Buffer_Interleaved_00.gltf)<br>[View](https://bghgary.github.io/glTF-Assets-Viewer/?folder=0&model=0) | [<img src="Figures/Thumbnails/Buffer_Interleaved_00.png" align="middle">](Figures/SampleImages/Buffer_Interleaved_00.png) | Float | Vector3 Float |
 | [01](Buffer_Interleaved_01.gltf)<br>[View](https://bghgary.github.io/glTF-Assets-Viewer/?folder=0&model=1) | [<img src="Figures/Thumbnails/Buffer_Interleaved_01.png" align="middle">](Figures/SampleImages/Buffer_Interleaved_01.png) | Float | Vector3 Byte |

--- a/Output/Mesh_PrimitiveAttribute/README.md
+++ b/Output/Mesh_PrimitiveAttribute/README.md
@@ -13,7 +13,7 @@ All values of Byte and Short are normalized unsigned.
 
 The following table shows the properties that are set for a given model.  
 
-|   | Sample Image | Vertex UV 0 | Vertex Normal | Vertex Tangent | Normal Texture |
+|   | Sample Image | Texture Coordinate Component Type | Vertex Normal | Vertex Tangent | Normal Texture |
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | [00](Mesh_PrimitiveAttribute_00.gltf)<br>[View](https://bghgary.github.io/glTF-Assets-Viewer/?folder=9&model=0) | [<img src="Figures/Thumbnails/Mesh_PrimitiveAttribute_00.png" align="middle">](Figures/SampleImages/Mesh_PrimitiveAttribute_00.png) | Float |   |   |   |
 | [01](Mesh_PrimitiveAttribute_01.gltf)<br>[View](https://bghgary.github.io/glTF-Assets-Viewer/?folder=9&model=1) | [<img src="Figures/Thumbnails/Mesh_PrimitiveAttribute_01.png" align="middle">](Figures/SampleImages/Mesh_PrimitiveAttribute_01.png) | Byte |   |   |   |

--- a/Source/ModelGroups/Buffer_Interleaved.cs
+++ b/Source/ModelGroups/Buffer_Interleaved.cs
@@ -70,19 +70,19 @@ namespace AssetGenerator
             void SetUvTypeFloat(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT;
-                properties.Add(new Property(PropertyName.VertexUV0, "Float"));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, "Float"));
             }
 
             void SetUvTypeTypeByte(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE;
-                properties.Add(new Property(PropertyName.VertexUV0, "Byte"));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, "Byte"));
             }
 
             void SetUvTypeTypeShort(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_USHORT;
-                properties.Add(new Property(PropertyName.VertexUV0, "Short"));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, "Short"));
             }
 
             void SetColorTypeFloat(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)

--- a/Source/ModelGroups/Mesh_PrimitiveAttribute.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveAttribute.cs
@@ -55,19 +55,19 @@ namespace AssetGenerator
             void SetVertexUVFloat(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.FLOAT;
-                properties.Add(new Property(PropertyName.VertexUV0, meshPrimitive.TextureCoordsComponentType));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, meshPrimitive.TextureCoordsComponentType));
             }
 
             void SetVertexUVByte(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_UBYTE;
-                properties.Add(new Property(PropertyName.VertexUV0, meshPrimitive.TextureCoordsComponentType));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, meshPrimitive.TextureCoordsComponentType));
             }
 
             void SetVertexUVShort(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 meshPrimitive.TextureCoordsComponentType = Runtime.MeshPrimitive.TextureCoordsComponentTypeEnum.NORMALIZED_USHORT;
-                properties.Add(new Property(PropertyName.VertexUV0, meshPrimitive.TextureCoordsComponentType));
+                properties.Add(new Property(PropertyName.TextureCoordinateComponentType, meshPrimitive.TextureCoordsComponentType));
             }
 
             void SetVertexNormal(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)

--- a/Source/Property.cs
+++ b/Source/Property.cs
@@ -106,7 +106,7 @@ namespace AssetGenerator
         AlphaMode,
         AlphaCutoff,
         DoubleSided,
-        VertexUV0,
+        TextureCoordinateComponentType,
         VertexNormal,
         VertexTangent,
         VertexColor,


### PR DESCRIPTION
There was no need for the 0 in either of these model groups. 'TextureCoordinate' is more accurate to the documentation, in my opinion, as well.

Fixes #408